### PR TITLE
Fix(roles): Correct role evaluation for existing role holders

### DIFF
--- a/role_manager.py
+++ b/role_manager.py
@@ -16,10 +16,10 @@ async def remove_role(member: discord.Member, role_name: str) -> bool:
 
 async def assign_role(member: discord.Member, role_name: str) -> bool:
     role = discord.utils.get(member.guild.roles, name=role_name)
-    if role:
+    if role and role not in member.roles:
         await member.add_roles(role)
-        return True
-    return False
+        return True # Role was newly assigned
+    return False # Role not assigned (or already present)
 
 async def handle_game_role_assignment(
     guild: discord.Guild,
@@ -90,9 +90,10 @@ async def handle_game_role_assignment(
         should_assign_role = True
 
     elif is_same:
-        # Same as latest identifier: just assign role if needed
-        if role_name not in [role.name for role in member.roles]:
-            should_assign_role = True
+        # Always run the role check if the identifier is the same.
+        # The assign_role function will handle not re-assigning a role,
+        # but this allows players who complete a game's criteria to be recognized.
+        should_assign_role = True
 
     if should_assign_role:
         can_receive_role = False


### PR DESCRIPTION
The previous role decision logic prevented re-evaluation for a player who already held the `pips-player` role. If a player retained their role from a previous game, they would not be re-evaluated upon completing the criteria for a new game, and thus the introduction message would not be sent.

This change modifies the `handle_game_role_assignment` function to ensure that the qualification check runs for every score submission for the current game number, regardless of whether the player already has the role.

Additionally, the `assign_role` function has been improved to only return `True` if a role was newly assigned. This makes the role assignment process more robust and prevents potential duplicate introduction messages.