### PR TITLE
feat(gisnep): Enhance feedback with stats and leaderboards

### DIFF
--- a/database.py
+++ b/database.py
@@ -34,7 +34,10 @@ def initialize_db():
                 connections_total_plays INTEGER DEFAULT 0,
                 connections_perfect_games INTEGER DEFAULT 0,
                 connections_purple_firsts INTEGER DEFAULT 0,
-                connections_avg_mistakes REAL DEFAULT 0.0
+                connections_avg_mistakes REAL DEFAULT 0.0,
+                gisnep_total_plays INTEGER DEFAULT 0,
+                gisnep_avg_seconds REAL DEFAULT 0.0,
+                gisnep_personal_best_seconds INTEGER -- Can be NULL
             )
         """)
         # Connections
@@ -85,11 +88,22 @@ def initialize_db():
         """)
         # Gisnep
         cursor.execute("""
-             CREATE TABLE IF NOT EXISTS gisnep_scores (
-                id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER, display_name TEXT,
-                game_number INTEGER, completion_time INTEGER,
-                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
-             )
+            CREATE TABLE IF NOT EXISTS gisnep_scores (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id TEXT NOT NULL,
+                display_name TEXT,
+                game_number INTEGER NOT NULL,
+                completion_time INTEGER NOT NULL, -- Stored in seconds
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS gisnep_puzzle_stats (
+                game_number INTEGER PRIMARY KEY,
+                total_solves INTEGER DEFAULT 0,
+                total_seconds INTEGER DEFAULT 0,
+                avg_seconds REAL DEFAULT 0.0
+            )
         """)
         # Bandle
         cursor.execute("""
@@ -389,6 +403,76 @@ def save_gisnep_score(user_id, display_name, game_number, completion_time):
     conn.commit()
     conn.close()
 
+def update_gisnep_puzzle_stats(game_number, completion_time):
+    """Updates the server-wide stats for a specific Gisnep puzzle."""
+    conn = sqlite3.connect(DB_NAME)
+    cursor = conn.cursor()
+    cursor.execute("SELECT total_solves, total_seconds FROM gisnep_puzzle_stats WHERE game_number = ?", (game_number,))
+    stats = cursor.fetchone()
+
+    if stats:
+        new_total_solves = stats[0] + 1
+        new_total_seconds = stats[1] + completion_time
+        new_avg_seconds = new_total_seconds / new_total_solves
+        cursor.execute("""
+            UPDATE gisnep_puzzle_stats
+            SET total_solves = ?, total_seconds = ?, avg_seconds = ?
+            WHERE game_number = ?
+        """, (new_total_solves, new_total_seconds, new_avg_seconds, game_number))
+    else:
+        cursor.execute("""
+            INSERT INTO gisnep_puzzle_stats (game_number, total_solves, total_seconds, avg_seconds)
+            VALUES (?, ?, ?, ?)
+        """, (game_number, 1, completion_time, float(completion_time)))
+    conn.commit()
+    conn.close()
+
+def update_gisnep_player_stats(user_id, display_name, completion_time):
+    """Updates a player's Gisnep stats and returns the new stats."""
+    conn = sqlite3.connect(DB_NAME)
+    cursor = conn.cursor()
+
+    # Ensure the player exists in the player_stats table
+    cursor.execute("SELECT user_id FROM player_stats WHERE user_id = ?", (user_id,))
+    if not cursor.fetchone():
+        cursor.execute("INSERT INTO player_stats (user_id, display_name) VALUES (?, ?)", (user_id, display_name))
+        conn.commit()
+
+    cursor.execute("""
+        SELECT gisnep_total_plays, gisnep_avg_seconds, gisnep_personal_best_seconds
+        FROM player_stats WHERE user_id = ?
+    """, (user_id,))
+    stats = cursor.fetchone()
+
+    total_plays, avg_seconds, personal_best = stats
+
+    # Safely handle None values
+    total_plays = total_plays or 0
+    avg_seconds = avg_seconds or 0.0
+
+    new_total_plays = total_plays + 1
+    new_avg_seconds = ((avg_seconds * total_plays) + completion_time) / new_total_plays
+
+    is_new_pb = False
+    if personal_best is None or completion_time < personal_best:
+        personal_best = completion_time
+        is_new_pb = True
+
+    cursor.execute("""
+        UPDATE player_stats
+        SET gisnep_total_plays = ?, gisnep_avg_seconds = ?, gisnep_personal_best_seconds = ?, display_name = ?
+        WHERE user_id = ?
+    """, (new_total_plays, new_avg_seconds, personal_best, display_name, user_id))
+    conn.commit()
+    conn.close()
+
+    return {
+        "is_new_pb": is_new_pb,
+        "personal_best": personal_best,
+        "avg_seconds": new_avg_seconds,
+        "total_plays": new_total_plays
+    }
+
 def save_bandle_score(user_id, display_name, game_number, attempts, total_score, bonus_completed, bonus_total, bonus_categories: dict[str, bool]):
     """Save a new Bandle score, including individual bonus round results."""
     conn = sqlite3.connect(DB_NAME)
@@ -668,27 +752,63 @@ def get_framed_leaderboard(period: str = 'overall'):
     conn.close()
     return leaderboard # Returns list of tuples
 
-def get_gisnep_leaderboard(period: str = 'overall'):
-    """Fetch Gisnep leaderboard data, supporting different periods and stats."""
+def get_gisnep_leaderboard(period: str = 'weekly'):
+    """Fetch enhanced Gisnep leaderboard data with superlatives."""
     conn = sqlite3.connect(DB_NAME)
     cursor = conn.cursor()
+
+    # 1. Get top 10 players by average solve time for the specified period
     where_clause, params = get_scores_by_period("gisnep_scores", period)
 
-    # Fetch relevant stats for Gisnep
     cursor.execute(f"""
-        SELECT display_name,
-               COUNT(*) AS games_played,
-               AVG(completion_time) AS avg_time,
-               MIN(completion_time) AS best_time
-        FROM gisnep_scores
-        {where_clause}
-        GROUP BY user_id, display_name
-        ORDER BY avg_time ASC, games_played DESC -- Rank by average time, then games played
+        SELECT
+            ps.display_name,
+            ps.gisnep_avg_seconds
+        FROM player_stats ps
+        JOIN (SELECT DISTINCT user_id FROM gisnep_scores {where_clause}) as period_players
+        ON ps.user_id = period_players.user_id
+        WHERE ps.gisnep_total_plays > 0
+        ORDER BY ps.gisnep_avg_seconds ASC
         LIMIT 10
     """, params)
-    leaderboard = cursor.fetchall()
+    top_players = cursor.fetchall()
+
+    # 2. Get superlatives for the week
+    mercury_award = None
+    scholar_award = None
+    if period == 'weekly':
+        weekly_where_clause, weekly_params = get_scores_by_period("gisnep_scores", 'weekly')
+
+        # The Mercury Award: Fastest single solve of the week
+        cursor.execute(f"""
+            SELECT display_name, MIN(completion_time) as fastest_time
+            FROM gisnep_scores
+            {weekly_where_clause}
+            GROUP BY user_id, display_name
+            ORDER BY fastest_time ASC
+            LIMIT 1
+        """, weekly_params)
+        mercury_award = cursor.fetchone()
+
+        # The Scholar Award: Completed all 7 puzzles this week
+        cursor.execute(f"""
+            SELECT display_name, COUNT(DISTINCT game_number) as puzzles_solved
+            FROM gisnep_scores
+            {weekly_where_clause}
+            GROUP BY user_id, display_name
+            HAVING puzzles_solved >= 7
+            ORDER BY puzzles_solved DESC
+            LIMIT 1
+        """, weekly_params)
+        scholar_award = cursor.fetchone()
+
     conn.close()
-    return leaderboard # Returns list of tuples
+
+    return {
+        "top_players": top_players,
+        "mercury_award": mercury_award,
+        "scholar_award": scholar_award
+    }
 
 def get_bandle_leaderboard(period: str = 'overall'):
     """Fetch Bandle leaderboard data, supporting different periods and stats."""
@@ -887,6 +1007,50 @@ def get_gisnep_stats(user_id: int) -> dict:
     return {
         "games_played": stats[0] or 0,
         "avg_time": stats[1] or 0
+    }
+
+def get_gisnep_puzzle_stats(game_number: int) -> dict:
+    """Fetches the stats for a specific Gisnep puzzle."""
+    conn = sqlite3.connect(DB_NAME)
+    cursor = conn.cursor()
+    cursor.execute("""
+        SELECT total_solves, avg_seconds
+        FROM gisnep_puzzle_stats
+        WHERE game_number = ?
+    """, (game_number,))
+    stats = cursor.fetchone()
+    conn.close()
+    if stats:
+        return {
+            "total_solves": stats[0],
+            "avg_seconds": stats[1]
+        }
+    return {
+        "total_solves": 0,
+        "avg_seconds": 0.0
+    }
+
+def get_player_gisnep_stats(user_id: str) -> dict:
+    """Fetches Gisnep-specific stats for a given user from the player_stats table."""
+    conn = sqlite3.connect(DB_NAME)
+    cursor = conn.cursor()
+    cursor.execute("""
+        SELECT gisnep_total_plays, gisnep_avg_seconds, gisnep_personal_best_seconds
+        FROM player_stats
+        WHERE user_id = ?
+    """, (user_id,))
+    stats = cursor.fetchone()
+    conn.close()
+    if stats:
+        return {
+            "total_plays": stats[0] or 0,
+            "avg_seconds": stats[1] or 0.0,
+            "personal_best": stats[2]
+        }
+    return {
+        "total_plays": 0,
+        "avg_seconds": 0.0,
+        "personal_best": None
     }
 
 def get_bandle_stats(user_id: int) -> dict:

--- a/embed_builder.py
+++ b/embed_builder.py
@@ -48,6 +48,57 @@ async def build_wordle_leaderboard_embed(title: str, leaderboard_data: dict, per
     embed.set_footer(text=emit_footer)
     return embed
 
+async def build_gisnep_leaderboard_embed(title: str, leaderboard_data: dict, period: str, color: discord.Color) -> discord.Embed:
+    """
+    Builds a Discord embed for the enhanced Gisnep leaderboard.
+    """
+    embed = discord.Embed(
+        title=title,
+        description=f"Period: {period.capitalize()} (Ranked by Average Solve Time)",
+        color=color
+    )
+
+    # --- Utility function for time formatting ---
+    def format_time(seconds):
+        if seconds is None:
+            return "N/A"
+        minutes = int(seconds // 60)
+        secs = int(seconds % 60)
+        return f"{minutes:02d}:{secs:02d}"
+
+    # Top Players
+    top_players = leaderboard_data.get("top_players")
+    if top_players:
+        medals = ["🥇", "🥈", "🥉"]
+        player_list = []
+        for i, (player, avg_seconds) in enumerate(top_players):
+            medal = medals[i] if i < len(medals) else f"**#{i+1}**"
+            player_list.append(f"{medal} **{player}** - ⏱️ Avg Time: {format_time(avg_seconds)}")
+        embed.add_field(name="🏆 Top Players", value="\n".join(player_list), inline=False)
+    else:
+        embed.add_field(name="🏆 Top Players", value="No scores recorded for this period.", inline=False)
+
+
+    # Weekly Accolades
+    if period == 'weekly':
+        accolades = []
+        mercury_award = leaderboard_data.get("mercury_award")
+        if mercury_award:
+            player, fastest_time = mercury_award
+            accolades.append(f"The Mercury Award 🏃💨: to **{player}** for the single fastest solve of the week at a blazing {format_time(fastest_time)}!")
+
+        scholar_award = leaderboard_data.get("scholar_award")
+        if scholar_award:
+            player, puzzles_solved = scholar_award
+            accolades.append(f"The Scholar Award 📚: to **{player}** for completing all {puzzles_solved} puzzles this week.")
+
+        if accolades:
+            embed.add_field(name="✨ Weekly Accolades", value="\n".join(accolades), inline=False)
+
+    emit_footer = f"Posted: {discord.utils.utcnow().strftime('%Y-%m-%d')}"
+    embed.set_footer(text=emit_footer)
+    return embed
+
 async def build_connections_leaderboard_embed(title: str, leaderboard_data: dict, period: str, color: discord.Color) -> discord.Embed:
     """
     Builds a Discord embed for the enhanced Connections leaderboard.

--- a/main_bot.py
+++ b/main_bot.py
@@ -142,11 +142,46 @@ async def on_message(message):
                         game_info["total_score"]
                     )
                 elif game_key == "gisnep":
+                    # Save score
                     config["save_score_function"](
-                        message.author.id, message.author.display_name, 
+                        str(message.author.id), message.author.display_name,
                         game_info["game_number"],
                         game_info["completion_time"]
                     )
+
+                    # Update puzzle stats
+                    database.update_gisnep_puzzle_stats(
+                        game_info["game_number"],
+                        game_info["completion_time"]
+                    )
+
+                    # Update player stats
+                    player_stats = database.update_gisnep_player_stats(
+                        str(message.author.id),
+                        message.author.display_name,
+                        game_info["completion_time"]
+                    )
+
+                    # Get server stats for the puzzle
+                    server_stats = database.get_gisnep_puzzle_stats(game_info["game_number"])
+
+                    # Generate commentary
+                    post_message = post_generator.generate_gisnep_post(
+                        message.author.display_name,
+                        game_info["game_number"],
+                        game_info["completion_time"],
+                        player_stats,
+                        server_stats
+                    )
+
+                    # Post commentary to the dedicated channel
+                    channel_name = config.get("chat_channel_name")
+                    game_channel = discord.utils.get(message.guild.channels, name=channel_name)
+                    if game_channel:
+                        await game_channel.send(post_message)
+                    else:
+                        print(f"Warning: Could not find channel '{channel_name}' for {config['name']}. Posting in original channel.")
+                        await message.channel.send(post_message)
                 elif game_key == "bandle":
                     config["save_score_function"](
                         message.author.id, message.author.display_name,
@@ -316,6 +351,15 @@ async def leaderboard(ctx, game="wordle", period="weekly"):
             leaderboard_data=leaderboard_data,
             period=period,
             color=discord.Color.purple()
+        )
+        await ctx.send(embed=embed)
+    elif game == "gisnep":
+        leaderboard_data = database.get_gisnep_leaderboard(period=period)
+        embed = await embed_builder.build_gisnep_leaderboard_embed(
+            title=f"📖 The Gisnep Gazette {period.capitalize()} 📖",
+            leaderboard_data=leaderboard_data,
+            period=period,
+            color=discord.Color.blue()
         )
         await ctx.send(embed=embed)
     else:

--- a/post_generator.py
+++ b/post_generator.py
@@ -48,6 +48,72 @@ def generate_wordle_post(display_name, game_number, attempts, skill, luck, updat
     # Combine and return the final message
     return f"{opening_line}\n{stat_spotlight}"
 
+def generate_gisnep_post(display_name, game_number, completion_time, player_stats, server_stats):
+    """Generates a dynamic Gisnep post based on the player's score and stats."""
+
+    import random
+
+    # --- Utility function for time formatting ---
+    def format_time(seconds):
+        if seconds is None:
+            return "N/A"
+        minutes = int(seconds // 60)
+        secs = int(seconds % 60)
+        return f"{minutes:02d}:{secs:02d}"
+
+    time_str = format_time(completion_time)
+    player_avg_str = format_time(player_stats.get('avg_seconds'))
+
+    # --- Part A: The Opening Line (Thematic) ---
+    openers = [
+        "Another chapter closed!",
+        "The plot thickens!",
+        "A quote for the ages, solved by",
+        "Right on the page!",
+        "The author would be proud."
+    ]
+    opening_line = f"{random.choice(openers)} {display_name} solved today's Gisnep in **{time_str}**."
+
+    # --- Part B: The Time Analysis (The Dynamic Element) ---
+    analysis_lines = []
+    is_new_pb = player_stats.get('is_new_pb', False)
+    player_avg = player_stats.get('avg_seconds', 0.0)
+    server_avg = server_stats.get('avg_seconds', 0.0)
+
+    # Prioritize the most exciting event: a new Personal Best.
+    if is_new_pb:
+        analysis_lines.append(f"🚀 **New Personal Best!** They absolutely shattered their old record!")
+    else:
+        # Compare to the server average for THIS puzzle
+        if server_avg > 0:
+            time_diff_server = server_avg - completion_time
+            if time_diff_server > 60:  # More than a minute faster
+                diff_m = int(time_diff_server / 60)
+                diff_s = int(time_diff_server % 60)
+                analysis_lines.append(f"⚡ They were **{diff_m}m {diff_s}s faster** than the server average today! A true speed reader!")
+
+        # Compare to the player's OWN average
+        if player_avg > 0:
+            time_diff_player = player_avg - completion_time
+            if time_diff_player > 45:
+                analysis_lines.append(f"🔥 That's significantly faster than their usual pace. They were in the zone!")
+
+    # Add a general comment based on absolute time
+    if completion_time < 180:  # Under 3 minutes
+        analysis_lines.append("An incredibly quick solve!")
+    elif completion_time > 600:  # Over 10 minutes
+        analysis_lines.append("That was a real head-scratcher of a quote, a thoughtful solve. 🧐")
+
+    # If no other conditions met, provide a default summary
+    if not analysis_lines:
+        analysis_lines.append(f"Their average time is now **{player_avg_str}**.")
+
+    # Choose one line of analysis to post
+    time_analysis = random.choice(analysis_lines)
+
+    # Combine and return the final message
+    return f"{opening_line}\n{time_analysis}"
+
 def generate_connections_post(display_name, game_number, game_info, updated_stats):
     """Generates a dynamic Connections post based on the player's score and stats."""
 


### PR DESCRIPTION
This commit introduces a major enhancement to the Gisnep minigame feedback and tracking.

The changes include:
- **Database Enhancements**:
  - The `gisnep_scores` table is updated to store more detailed information.
  - A new `gisnep_puzzle_stats` table is added to track server-wide stats for each puzzle.
  - The `player_stats` table is extended to include long-term Gisnep performance metrics like total plays, average time, and personal bests.

- **New Score Submission Workflow**:
  - When a Gisnep score is submitted, the bot now saves the score, updates puzzle and player statistics, and generates a dynamic commentary post.
  - This new post is sent to a dedicated Gisnep channel, providing fun and engaging feedback based on the player's performance relative to their own average, the server average, and their personal best.

- **Enhanced Leaderboards**:
  - A new, enhanced leaderboard for Gisnep has been created.
  - It ranks players by their average solve time and includes weekly accolades for the fastest solve and for completing all puzzles in a week.
  - The leaderboard is presented in a rich embed format for better readability.