### PR TITLE
Fix Bandle score processing and add total_score

### DIFF
--- a/Minigame Scores Examples.fods
+++ b/Minigame Scores Examples.fods
@@ -731,7 +731,10 @@
      <table:table-cell table:style-name="ce7" office:value-type="string" calcext:value-type="string">
       <text:p>badge</text:p>
      </table:table-cell>
-     <table:table-cell table:number-columns-repeated="1016"/>
+     <table:table-cell table:style-name="ce7" office:value-type="string" calcext:value-type="string">
+      <text:p>total_score</text:p>
+     </table:table-cell>
+     <table:table-cell table:number-columns-repeated="1015"/>
     </table:table-row>
     <table:table-row table:style-name="ro6">
      <table:table-cell table:style-name="ce7" office:value-type="string" calcext:value-type="string"><text:p>Bandle #932 6/6</text:p><text:p>🟥🟥🟥🟥🟥🟩</text:p><text:p>Found: 359/378 (95%)</text:p><text:p>Current Daily Streak: 78 (max 78)</text:p><text:p>Bonus Rounds: 6/8 🎤  🖼️  🌍  📅  💿  ⏱️  </text:p><text:p>#Bandle #Heardle </text:p><text:p>https://bandle.app</text:p>
@@ -754,7 +757,11 @@
      <table:table-cell table:style-name="ce7" office:value-type="float" office:value="78" calcext:value-type="float">
       <text:p>78</text:p>
      </table:table-cell>
-     <table:table-cell table:number-columns-repeated="1017"/>
+     <table:table-cell table:number-columns-repeated="1"/>
+     <table:table-cell table:style-name="ce7" office:value-type="float" office:value="40" calcext:value-type="float">
+      <text:p>40</text:p>
+     </table:table-cell>
+     <table:table-cell table:number-columns-repeated="1015"/>
     </table:table-row>
     <table:table-row table:style-name="ro7">
      <table:table-cell table:style-name="ce7" office:value-type="string" calcext:value-type="string"><text:p>Bandle #944 x/6</text:p><text:p>🟥⬛⬛⬛⬛🟥</text:p><text:p>Found: 155/172 (90.1%)</text:p><text:p>Current Daily Streak: 0 (max 71)</text:p>
@@ -771,7 +778,11 @@
      <table:table-cell table:number-columns-repeated="3" table:style-name="ce7" office:value-type="float" office:value="0" calcext:value-type="float">
       <text:p>0</text:p>
      </table:table-cell>
-     <table:table-cell table:number-columns-repeated="1017"/>
+     <table:table-cell table:number-columns-repeated="1"/>
+     <table:table-cell table:style-name="ce7" office:value-type="float" office:value="0" calcext:value-type="float">
+      <text:p>0</text:p>
+     </table:table-cell>
+     <table:table-cell table:number-columns-repeated="1015"/>
     </table:table-row>
     <table:table-row table:style-name="ro4">
      <table:table-cell table:style-name="ce7" office:value-type="string" calcext:value-type="string"><text:p>Bandle #947 3/6</text:p><text:p>🟥🟨🟩⬜⬜⬜</text:p><text:p>Found: 353/370 (95.4%)</text:p><text:p>Current Daily Streak: 163 (max 163)</text:p><text:p>#Bandle #Heardle </text:p><text:p>https://bandle.app</text:p>
@@ -794,7 +805,10 @@
      <table:table-cell table:style-name="ce7" office:value-type="string" calcext:value-type="string">
       <text:p>stoplight guesses</text:p>
      </table:table-cell>
-     <table:table-cell table:number-columns-repeated="1016"/>
+     <table:table-cell table:style-name="ce7" office:value-type="float" office:value="40" calcext:value-type="float">
+      <text:p>40</text:p>
+     </table:table-cell>
+     <table:table-cell table:number-columns-repeated="1015"/>
     </table:table-row>
     <table:table-row table:style-name="ro2" table:number-rows-repeated="1048571">
      <table:table-cell table:number-columns-repeated="1024"/>

--- a/database.py
+++ b/database.py
@@ -121,6 +121,7 @@ def initialize_db():
                 bonus_rounds_completed INTEGER,
                 bonus_rounds_total INTEGER,
                 bonus_emojis TEXT,
+                total_score INTEGER,
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             );
         """)
@@ -496,7 +497,7 @@ def update_gisnep_player_stats(user_id, display_name, completion_time):
         "total_plays": new_total_plays
     }
 
-def save_bandle_score(user_id, display_name, game_number, attempts, found_total, found_percentage, current_streak, max_streak, bonus_rounds_completed, bonus_rounds_total, bonus_emojis):
+def save_bandle_score(user_id, display_name, game_number, attempts, found_total, found_percentage, current_streak, max_streak, bonus_rounds_completed, bonus_rounds_total, bonus_emojis, total_score):
     """Save a new Bandle score."""
     conn = sqlite3.connect(DB_NAME)
     cursor = conn.cursor()
@@ -505,12 +506,12 @@ def save_bandle_score(user_id, display_name, game_number, attempts, found_total,
             INSERT INTO bandle_scores (
                 user_id, display_name, game_number, attempts, found_total,
                 found_percentage, current_streak, max_streak,
-                bonus_rounds_completed, bonus_rounds_total, bonus_emojis
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                bonus_rounds_completed, bonus_rounds_total, bonus_emojis, total_score
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """, (
             user_id, display_name, game_number, attempts, found_total,
             found_percentage, current_streak, max_streak,
-            bonus_rounds_completed, bonus_rounds_total, bonus_emojis
+            bonus_rounds_completed, bonus_rounds_total, bonus_emojis, total_score
         ))
         conn.commit()
         print(f"DB: Saved Bandle score for {display_name} - Game #{game_number}")

--- a/main_bot.py
+++ b/main_bot.py
@@ -184,13 +184,18 @@ async def on_message(message):
                         await message.channel.send(post_message)
                 elif game_key == "bandle":
                     config["save_score_function"](
-                        message.author.id, message.author.display_name,
+                        message.author.id,
+                        message.author.display_name,
                         game_info["game_number"],
                         game_info["attempts"],
-                        game_info["total_score"],
-                        game_info["bonus_completed"],
-                        game_info["bonus_total"],
-                        game_info.get("bonus_categories", {}) # Pass the bonus categories dictionary
+                        game_info["found_total"],
+                        game_info["found_percentage"],
+                        game_info["current_streak"],
+                        game_info["max_streak"],
+                        game_info["bonus_rounds_completed"],
+                        game_info["bonus_rounds_total"],
+                        game_info["bonus_emojis"],
+                        game_info["total_score"]
                     )
                 elif game_key == "minute_cryptic":
                     config["save_score_function"](

--- a/score_parser.py
+++ b/score_parser.py
@@ -223,6 +223,18 @@ def parse_gisnep_score(message_content: str) -> Optional[Dict[str, Any]]:
         "completion_time": total_seconds
     }
 
+def calculate_bandle_score(attempts: int, bonus_rounds_completed: int) -> int:
+    """
+    Calculates the score for Bandle based on attempts and bonus rounds.
+    """
+    # Base score: 60 for 1 attempt, 50 for 2, ..., 10 for 6. 0 for failed (7 attempts).
+    base_score = max(0, (7 - attempts) * 10)
+
+    # Bonus points for each completed bonus round
+    bonus_score = bonus_rounds_completed * 5
+
+    return base_score + bonus_score
+
 def parse_bandle_score(message_content: str) -> Optional[Dict[str, Any]]:
     """Parses a Bandle score from a message, including individual bonus rounds."""
     match = BANDLE_PATTERN.search(message_content)
@@ -250,6 +262,9 @@ def parse_bandle_score(message_content: str) -> Optional[Dict[str, Any]]:
     current_streak = int(streak_match.group(1)) if streak_match else 0
     max_streak = int(max_streak_match.group(1)) if max_streak_match else 0
 
+    # Calculate the total score
+    total_score = calculate_bandle_score(attempts, bonus_rounds_completed)
+
     return {
         "game_number": game_number,
         "attempts": attempts,
@@ -260,7 +275,8 @@ def parse_bandle_score(message_content: str) -> Optional[Dict[str, Any]]:
         "bonus_rounds_completed": bonus_rounds_completed,
         "bonus_rounds_total": bonus_rounds_total,
         "bonus_emojis": bonus_emojis,
-        "solved": solved
+        "solved": solved,
+        "total_score": total_score
     }
     
 def parse_minute_cryptic_score(message_content: str) -> Optional[Dict[str, Any]]:

--- a/test_score_parser.py
+++ b/test_score_parser.py
@@ -175,8 +175,23 @@ class TestExamplesSheet(unittest.TestCase):
         cls.fods_path = os.path.join(script_dir, cls.fods_name)
 
         # soffice_refresh_fods(cls.ods_path)
+        import io
+        import zipfile
+        with open(cls.fods_path, 'rb') as f:
+            fods_content = f.read()
 
-        cls.doc = odf.opendocument.load(cls.fods_path)
+        in_memory_zip = io.BytesIO()
+        with zipfile.ZipFile(in_memory_zip, 'w', zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr('mimetype', 'application/vnd.oasis.opendocument.spreadsheet')
+            zf.writestr('META-INF/manifest.xml', '''<?xml version="1.0" encoding="UTF-8"?>
+<manifest:manifest xmlns:manifest="urn:oasis:names:tc:opendocument:xmlns:manifest:1.0">
+  <manifest:file-entry manifest:media-type="application/vnd.oasis.opendocument.spreadsheet" manifest:full-path="/"/>
+  <manifest:file-entry manifest:media-type="text/xml" manifest:full-path="content.xml"/>
+</manifest:manifest>''')
+            zf.writestr('content.xml', fods_content)
+        in_memory_zip.seek(0)
+
+        cls.doc = odf.opendocument.load(in_memory_zip)
         cls.sheets = spreadsheet_xml_to_dict(cls.doc)
         # log.debug(pprint.pformat(cls.sheets))
 
@@ -246,7 +261,7 @@ Full parsed object:
         self.do_parse_test(
             sheet = self.sheets['Bandle'],
             parsefn = score_parser.parse_bandle_score,
-            matchfields = ['game_number', 'attempts', 'solved', 'bonus_rounds_completed', 'bonus_rounds_total', 'bonus_emojis', 'current_streak', 'max_streak'])
+            matchfields = ['game_number', 'attempts', 'solved', 'bonus_rounds_completed', 'bonus_rounds_total', 'bonus_emojis', 'current_streak', 'max_streak', 'total_score'])
 
 class TestPipsParser(unittest.TestCase):
     def test_calculate_pips_score(self):


### PR DESCRIPTION
This change fixes a `KeyError: 'total_score'` that occurred when processing Bandle scores. The `parse_bandle_score` function in `score_parser.py` did not calculate a `total_score`, but the main bot logic expected one.

This commit introduces the following changes:
- Adds a `calculate_bandle_score` function to `score_parser.py` to calculate a score based on attempts and bonus rounds completed.
- Updates `parse_bandle_score` to include the `total_score` in the returned dictionary.
- Adds a `total_score` column to the `bandle_scores` table in `database.py`.
- Updates `save_bandle_score` to store the `total_score`.
- Corrects the call to `save_bandle_score` in `main_bot.py` to pass the correct arguments.
- Updates the tests to validate the `total_score` calculation.