### PR TITLE
Fixes duplicate introduction messages and adds Bandle posts

### DIFF
--- a/game_config.py
+++ b/game_config.py
@@ -17,7 +17,6 @@ GAME_CONFIGS = {
         "get_latest_game_number_function": database.get_latest_game_number_from_db,
         "update_latest_game_number_function": database.update_latest_game_number_in_db,
         "create_acknowledgement": score_parser.create_wordle_acknowledgement,
-        "create_introduction": score_parser.create_wordle_introduction,
         "game_number_key": "game_number"  # Key for game number
     },
     "connections": {
@@ -31,7 +30,6 @@ GAME_CONFIGS = {
         "get_latest_game_number_function": database.get_latest_game_number_from_db,
         "update_latest_game_number_function": database.update_latest_game_number_in_db,
         "create_acknowledgement": score_parser.create_connections_acknowledgement,
-        "create_introduction": score_parser.create_connections_introduction,
         "game_number_key": "game_number"  # Key for game number
     },
 "framed": {

--- a/main_bot.py
+++ b/main_bot.py
@@ -197,6 +197,24 @@ async def on_message(message):
                         game_info["bonus_emojis"],
                         game_info["total_score"]
                     )
+                    player_stats = database.update_bandle_player_stats(
+                        message.author.id,
+                        message.author.display_name,
+                        game_info["attempts"],
+                        game_info["bonus_rounds_completed"]
+                    )
+                    post_message = post_generator.generate_bandle_post(
+                        message.author.display_name,
+                        game_info,
+                        player_stats
+                    )
+                    channel_name = config.get("chat_channel_name")
+                    game_channel = discord.utils.get(message.guild.channels, name=channel_name)
+                    if game_channel:
+                        await game_channel.send(post_message)
+                    else:
+                        print(f"Warning: Could not find channel '{channel_name}' for {config['name']}. Posting in original channel.")
+                        await message.channel.send(post_message)
                 elif game_key == "minute_cryptic":
                     config["save_score_function"](
                         message.author.id, message.author.display_name,
@@ -270,7 +288,7 @@ async def on_message(message):
                     )
     
                     # Post introduction message if required
-                    if should_introduce:
+                    if should_introduce and game_key not in ["wordle", "connections", "gisnep", "bandle"]:
                         await role_manager.introduce_player_in_game_channel(
                             message.guild,
                             message.author,

--- a/score_parser.py
+++ b/score_parser.py
@@ -510,35 +510,9 @@ def is_pips_message(message_content: str) -> bool:
     
 def create_wordle_acknowledgement(display_name: str, game_info: Dict[str, Any]) -> str:
     return "🤖"
-  
-def create_wordle_introduction(display_name: str, game_info: Dict[str, Any]) -> str:
-    """Create an informative introduction message for Wordle scores."""
-    user_id = game_info.get("user_id")
-    stats = database.get_wordle_stats(user_id)
-    
-    game_number = game_info.get("game_number", "?")
-    attempts = game_info.get("attempts", "?")
-    hard_mode = game_info.get("hard_mode", False)
-    hard_mode_text = " (Hard Mode)" if hard_mode else ""
-
-    message = (f"**{display_name}** just finished Wordle {game_number} in {attempts}/6{hard_mode_text}!\n"
-               f"They have played {stats['games_played']} games with an average score of {stats['avg_score']:.2f}.")
-    return message
 
 def create_connections_acknowledgement(display_name: str, game_info: Dict[str, Any]) -> str:
     return "🤖"
-
-def create_connections_introduction(display_name: str, game_info: Dict[str, Any]) -> str:
-    """Create an informative introduction message for Connections scores."""
-    user_id = game_info.get("user_id")
-    stats = database.get_connections_stats(user_id)
-
-    puzzle_number = game_info.get("puzzle_number", "?")
-    total_score = game_info.get("total_score", "?")
-
-    message = (f"**{display_name}** just finished Connections #{puzzle_number} with a score of {total_score}!\n"
-               f"They have played {stats['games_played']} games with an average score of {stats['avg_score']:.2f}.")
-    return message
 
 def create_framed_acknowledgement(display_name: str, game_info: Dict[str, Any]) -> str:
     return "🤖"


### PR DESCRIPTION
- Removes `create_wordle_introduction` and `create_connections_introduction` from `score_parser.py` to prevent duplicate introduction messages for Wordle and Connections.
- Updates `game_config.py` to remove the references to the deleted functions.
- Adds post generation for Bandle scores in `main_bot.py` by calling `post_generator.generate_bandle_post`.
- Prevents the generic introduction message from being posted for Wordle, Connections, Gisnep, and Bandle, as they now have their own custom post generation.