### PR TITLE
Fix weekly/monthly leaderboard posting for Connections and Gisnep

### DIFF
--- a/database.py
+++ b/database.py
@@ -164,6 +164,26 @@ def initialize_db():
         conn.commit()
         print("DB: All tables created or verified.")
 
+        # --- Add created_at columns to connections_scores and gisnep_scores (migration) ---
+        try:
+            cursor.execute("ALTER TABLE connections_scores ADD COLUMN created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP;")
+            conn.commit()
+            print("DB: Added created_at column to connections_scores.")
+        except sqlite3.OperationalError as e:
+            if "duplicate column name" in str(e):
+                print("DB: created_at column already exists in connections_scores.")
+            else:
+                raise e
+        try:
+            cursor.execute("ALTER TABLE gisnep_scores ADD COLUMN created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP;")
+            conn.commit()
+            print("DB: Added created_at column to gisnep_scores.")
+        except sqlite3.OperationalError as e:
+            if "duplicate column name" in str(e):
+                print("DB: created_at column already exists in gisnep_scores.")
+            else:
+                raise e
+
         # --- Add Bandle columns to player_stats (migration) ---
         try:
             cursor.execute("ALTER TABLE player_stats ADD COLUMN bandle_total_plays INTEGER DEFAULT 0;")

--- a/main_bot.py
+++ b/main_bot.py
@@ -462,6 +462,14 @@ async def post_scores(period: str):
                 period=period,
                 color=embed_color
             )
+
+        elif game_name == "Gisnep":
+            leaderboard_embed = await embed_builder.build_gisnep_leaderboard_embed(
+                title=f"📖 The Gisnep Gazette {period.capitalize()} 📖",
+                leaderboard_data=scores,
+                period=period,
+                color=embed_color
+            )
         else:
             # Format data for embed for other games
             formatted_scores_for_embed = []


### PR DESCRIPTION
This commit addresses two issues that prevented the scheduled leaderboards for Connections and Gisnep from being posted.

1.  Adds a database migration to `database.py` to create the `created_at` column in the `connections_scores` and `gisnep_scores` tables if they do not already exist. This resolves the "no such column: created_at" error.

2.  Updates the `post_scores` function in `main_bot.py` to include a specific handler for Gisnep leaderboards. This ensures that the correct embed builder function is called, preventing the posting from failing due to an incompatible data structure.