### PR TITLE
Refactor: Remove redundant code for Pips leaderboards

### DIFF
--- a/main_bot.py
+++ b/main_bot.py
@@ -507,9 +507,6 @@ async def post_scores(period: str):
                     elif game_name == "Word Salad":
                         player_data["avg"] = player_data["avg_score"]
                         player_data["total"] = player_data["total_score"]
-                    elif game_name == "Pips":
-                        player_data["total_score"] = player_data["total_score"]
-                        player_data["cookie_count"] = player_data["cookie_count"]
                     formatted_scores_for_embed.append(player_data)
 
             if formatted_scores_for_embed:


### PR DESCRIPTION
During an investigation of the leaderboard posting mechanism, it was found that the `post_scores` function in `main_bot.py` contained redundant self-assignments for Pips' score data.

This change removes the unnecessary `elif` block for Pips, improving code clarity and maintainability without affecting functionality.