### PR TITLE
Fix: Correct arguments for generate_wordle_post

### DIFF
--- a/main_bot.py
+++ b/main_bot.py
@@ -185,8 +185,9 @@ async def on_message(message):
                 # 4. Generate post message (AFTER roles are handled)
                 if game_key == "wordle":
                     post_message = post_generator.generate_wordle_post(
-                        message.author.display_name, game_info["game_number"], game_info["attempts"],
-                        game_info.get("skill"), game_info.get("luck"), updated_stats
+                        message.author.display_name,
+                        game_info,
+                        updated_stats
                     )
                 elif game_key == "connections":
                     post_message = post_generator.generate_connections_post(


### PR DESCRIPTION
The `generate_wordle_post` function was being called with 6 arguments, but it is defined to accept only 3. This caused a `TypeError` when processing Wordle scores.

This commit corrects the function call in `main_bot.py` to pass the arguments correctly:
- `display_name` (string)
- `game_info` (dictionary)
- `updated_stats` (dictionary)

This aligns the call with the function's signature and resolves the error.