### PR TITLE
Refactor: Disable introduction and acknowledgement posts for specific…

### DIFF
--- a/game_config.py
+++ b/game_config.py
@@ -59,8 +59,6 @@ GAME_CONFIGS = {
         "embed_builder_function": embed_builder.build_gisnep_leaderboard_embed,
         "get_latest_game_number_function": database.get_latest_game_number_from_db,
         "update_latest_game_number_function": database.update_latest_game_number_in_db,
-        "create_acknowledgement": score_parser.create_gisnep_acknowledgement,
-        "create_introduction": score_parser.create_gisnep_introduction,
         "game_number_key": "game_number"
     },
     "framed": {
@@ -75,8 +73,6 @@ GAME_CONFIGS = {
         "embed_builder_function": embed_builder.build_leaderboard_embed,
         "get_latest_game_number_function": database.get_latest_game_number_from_db,
         "update_latest_game_number_function": database.update_latest_game_number_in_db,
-        "create_acknowledgement": score_parser.create_framed_acknowledgement,
-        "create_introduction": score_parser.create_framed_introduction,
         "game_number_key": "game_number"
     },
     "bandle": {
@@ -91,8 +87,6 @@ GAME_CONFIGS = {
         "embed_builder_function": embed_builder.build_leaderboard_embed,
         "get_latest_game_number_function": database.get_latest_game_number_from_db,
         "update_latest_game_number_function": database.update_latest_game_number_in_db,
-        "create_acknowledgement": score_parser.create_bandle_acknowledgement,
-        "create_introduction": score_parser.create_bandle_introduction,
         "game_number_key": "game_number"
     },
     "minute_cryptic": {
@@ -123,8 +117,6 @@ GAME_CONFIGS = {
         "embed_builder_function": embed_builder.build_leaderboard_embed,
         "get_latest_game_number_function": database.get_latest_game_number_from_db,
         "update_latest_game_number_function": database.update_latest_game_number_in_db,
-        "create_acknowledgement": score_parser.create_word_salad_acknowledgement,
-        "create_introduction": score_parser.create_word_salad_introduction,
         "game_number_key": "game_number"
     },
     "pips": {


### PR DESCRIPTION
… games

This change addresses an issue where the bot would post two messages for a single score submission for the games Framed, Bandle, Word Salad, and Gisnep.

The double posting was caused by two systems running in parallel:
1. The modern `post_generator.py`, which creates a dynamic, detailed post.
2. An older introduction/acknowledgement system that would post a separate message.

This commit resolves the issue by removing the `create_introduction` and `create_acknowledgement` configurations for these four games from `game_config.py`. This ensures that only the post from `post_generator.py` is sent.

The calling code in `main_bot.py` uses the `dict.get()` method to access these configurations. This method safely handles the missing keys by returning `None`, preventing any errors from occurring.