### PR TITLE
feat: Add support for Sexaginta-Quattuordle

### DIFF
--- a/Minigame Scores Examples.fods
+++ b/Minigame Scores Examples.fods
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <office:document xmlns:presentation="urn:oasis:names:tc:opendocument:xmlns:presentation:1.0" xmlns:css3t="http://www.w3.org/TR/css3-text/" xmlns:grddl="http://www.w3.org/2003/g/data-view#" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:formx="urn:openoffice:names:experimental:ooxml-odf-interop:xmlns:form:1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:chart="urn:oasis:names:tc:opendocument:xmlns:chart:1.0" xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:oooc="http://openoffice.org/2004/calc" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:ooow="http://openoffice.org/2004/writer" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rpt="http://openoffice.org/2005/report" xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0" xmlns:config="urn:oasis:names:tc:opendocument:xmlns:config:1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:ooo="http://openoffice.org/2004/office" xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:dr3d="urn:oasis:names:tc:opendocument:xmlns:dr3d:1.0" xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0" xmlns:of="urn:oasis:names:tc:opendocument:xmlns:of:1.2" xmlns:calcext="urn:org:documentfoundation:names:experimental:calc:xmlns:calcext:1.0" xmlns:tableooo="http://openoffice.org/2009/table" xmlns:drawooo="http://openoffice.org/2010/draw" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" xmlns:dom="http://www.w3.org/2001/xml-events" xmlns:field="urn:openoffice:names:experimental:ooo-ms-interop:xmlns:field:1.0" xmlns:math="http://www.w3.org/1998/Math/MathML" xmlns:form="urn:oasis:names:tc:opendocument:xmlns:form:1.0" xmlns:script="urn:oasis:names:tc:opendocument:xmlns:script:1.0" xmlns:xforms="http://www.w3.org/2002/xforms" office:version="1.3" office:mimetype="application/vnd.oasis.opendocument.spreadsheet">
- <office:meta><meta:generator>LibreOffice/7.3.7.2$Linux_X86_64 LibreOffice_project/30$Build-2</meta:generator><meta:document-statistic meta:table-count="6" meta:cell-count="79" meta:object-count="0"/></office:meta>
+ <office:meta><meta:generator>Jules</meta:generator><meta:document-statistic meta:table-count="7" meta:cell-count="88" meta:object-count="0"/></office:meta>
  <office:settings>
   <config:config-item-set config:name="ooo:view-settings">
    <config:config-item config:name="VisibleAreaTop" config:type="int">0</config:config-item>
@@ -62,7 +62,10 @@
      <config:config-item config:name="CodeName" config:type="string">Gisnep</config:config-item>
     </config:config-item-map-entry>
     <config:config-item-map-entry config:name="New Game Template">
-     <config:config-item config:name="CodeName" config:type="string">New Game Template</config:config-item>
+     <config:config-item config:name="CodeName" config:type="string">New_Game_Template</config:config-item>
+    </config:config-item-map-entry>
+    <config:config-item-map-entry config:name="Sexaginta">
+     <config:config-item config:name="CodeName" config:type="string">Sexaginta</config:config-item>
     </config:config-item-map-entry>
    </config:config-item-map-named>
   </config:config-item-set>
@@ -480,6 +483,9 @@
   <style:style style:name="ta6" style:family="table" style:master-page-name="PageStyle_5f_New_20_Game_20_Template">
    <style:table-properties table:display="true" style:writing-mode="lr-tb"/>
   </style:style>
+  <style:style style:name="ta7" style:family="table" style:master-page-name="PageStyle_5f_Sexaginta">
+   <style:table-properties table:display="true" style:writing-mode="lr-tb"/>
+  </style:style>
   <style:style style:name="ce1" style:family="table-cell" style:parent-style-name="Default">
    <style:table-cell-properties style:text-align-source="value-type" style:repeat-content="false" fo:wrap-option="no-wrap" style:direction="ltr" style:rotation-angle="0" style:rotation-align="none" style:shrink-to-fit="false" style:vertical-align="bottom" loext:vertical-justify="auto"/>
    <style:paragraph-properties css3t:text-justify="auto" fo:margin-left="0in" style:writing-mode="page"/>
@@ -560,6 +566,14 @@
    <style:footer-first style:display="false"/>
   </style:master-page>
   <style:master-page style:name="PageStyle_5f_New_20_Game_20_Template" style:display-name="PageStyle_New Game Template" style:page-layout-name="pm1">
+   <style:header style:display="false"/>
+   <style:header-left style:display="false"/>
+   <style:header-first style:display="false"/>
+   <style:footer style:display="false"/>
+   <style:footer-left style:display="false"/>
+   <style:footer-first style:display="false"/>
+  </style:master-page>
+  <style:master-page style:name="PageStyle_5f_Sexaginta" style:display-name="PageStyle_Sexaginta" style:page-layout-name="pm1">
    <style:header style:display="false"/>
    <style:header-left style:display="false"/>
    <style:header-first style:display="false"/>
@@ -919,6 +933,74 @@
      <table:table-cell table:number-columns-repeated="1024"/>
     </table:table-row>
     <table:table-row table:style-name="ro2">
+     <table:table-cell table:number-columns-repeated="1024"/>
+    </table:table-row>
+   </table:table>
+   <table:table table:name="Sexaginta" table:style-name="ta7">
+    <table:table-column table:style-name="co1" table:default-cell-style-name="Default"/>
+    <table:table-column table:style-name="co2" table:default-cell-style-name="Default"/>
+    <table:table-column table:style-name="co3" table:default-cell-style-name="Default"/>
+    <table:table-column table:style-name="co2" table:number-columns-repeated="1021" table:default-cell-style-name="Default"/>
+    <table:table-row table:style-name="ro1">
+     <table:table-cell table:style-name="ce7" office:value-type="string" calcext:value-type="string">
+      <text:p>share_text</text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="ce7" office:value-type="string" calcext:value-type="string">
+      <text:p>game_number</text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="ce7" office:value-type="string" calcext:value-type="string">
+      <text:p>guesses_used</text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="ce7" office:value-type="string" calcext:value-type="string">
+      <text:p>guesses_allowed</text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="ce7" office:value-type="string" calcext:value-type="string">
+      <text:p>score_value</text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="ce7" office:value-type="string" calcext:value-type="string">
+      <text:p>pct</text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="ce7" office:value-type="string" calcext:value-type="string">
+      <text:p>seed</text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="ce7" office:value-type="string" calcext:value-type="string">
+      <text:p>weighted_score</text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="ce7" office:value-type="string" calcext:value-type="string">
+      <text:p>performance_pct</text:p>
+     </table:table-cell>
+     <table:table-cell table:number-columns-repeated="1015"/>
+    </table:table-row>
+    <table:table-row table:style-name="ro3">
+     <table:table-cell table:style-name="ce7" office:value-type="string" calcext:value-type="string"><text:p>#SexagintaQuattuordle 1274 67/70 (score 2272, 75%)</text:p><text:p>🟧🟨💚🟥🟪🟩🟧🟨</text:p><text:p>🟩🟪🟧🟩🟪🟨🟧🟨</text:p><text:p>🟩🟩🟩🟪🟨🟪🟥🟩</text:p><text:p>🟣🟦💙🟨🟦🟩🟩🟩</text:p><text:p>🟦🟢🟥🟠🟦❤️🟥🟡</text:p><text:p>🧡🟦💛🟥🟪🟨🟧🟧</text:p><text:p>🟨🟧🟨🟦🟪🟧🟦🟥</text:p><text:p>🟦🟧🟦🟨🟪🟦🔵🟧</text:p><text:p>https://64ordle.au/?seed=1397</text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="ce7" office:value-type="float" office:value="1274" calcext:value-type="float">
+      <text:p>1274</text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="ce7" office:value-type="string" office:value="67" calcext:value-type="string">
+      <text:p>67</text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="ce7" office:value-type="float" office:value="70" calcext:value-type="float">
+      <text:p>70</text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="ce7" office:value-type="float" office:value="2272" calcext:value-type="float">
+      <text:p>2272</text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="ce7" office:value-type="float" office:value="75" calcext:value-type="float">
+      <text:p>75</text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="ce7" office:value-type="float" office:value="1397" calcext:value-type="float">
+      <text:p>1397</text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="ce7" office:value-type="float" office:value="228" calcext:value-type="float">
+      <text:p>228</text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="ce7" office:value-type="float" office:value="59.4" calcext:value-type="float">
+      <text:p>59.4</text:p>
+     </table:table-cell>
+     <table:table-cell table:number-columns-repeated="1015"/>
+    </table:table-row>
+    <table:table-row table:style-name="ro2" table:number-rows-repeated="1048573">
      <table:table-cell table:number-columns-repeated="1024"/>
     </table:table-row>
    </table:table>

--- a/database.py
+++ b/database.py
@@ -37,7 +37,10 @@ def initialize_db():
                 connections_avg_mistakes REAL DEFAULT 0.0,
                 gisnep_total_plays INTEGER DEFAULT 0,
                 gisnep_avg_seconds REAL DEFAULT 0.0,
-                gisnep_personal_best_seconds INTEGER -- Can be NULL
+                gisnep_personal_best_seconds INTEGER, -- Can be NULL
+                sexaginta_total_plays INTEGER DEFAULT 0,
+                sexaginta_avg_pct REAL DEFAULT 0.0,
+                sexaginta_avg_weighted_score REAL DEFAULT 0.0
             )
         """)
         # Connections
@@ -160,10 +163,25 @@ def initialize_db():
             )
         """)
 
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS sexaginta_scores (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id TEXT NOT NULL,
+                display_name TEXT,
+                game_number INTEGER NOT NULL,
+                guesses_used TEXT,
+                guesses_allowed INTEGER,
+                percent_solved REAL,
+                weighted_score REAL,
+                grid_text TEXT,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            );
+        """)
+
         conn.commit()
         print("DB: All tables created or verified.")
-        }
 
+        migrations = {}
         for table, old_column in migrations.items():
             if old_column:
                 try:
@@ -183,7 +201,7 @@ def initialize_db():
         initial_games = [
             ('Wordle', '0'), ('Connections', '0'), ('Framed', '0'),
             ('Gisnep', '0'), ('Bandle', '0'), ('Minute Cryptic', '2000-01-01'),
-            ('Pips', '0')
+            ('Pips', '0'), ('Sexaginta', '0')
         ]
         try:
             cursor.executemany(
@@ -226,6 +244,26 @@ def save_wordle_score(user_id, display_name, game_number, attempts, skill=None, 
         INSERT INTO wordle_scores (user_id, display_name, game_number, attempts, skill, luck, hard_mode, total_score, created_at)
         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
     """, (user_id, display_name, game_number, attempts, skill, luck, hard_mode, total_score, created_at))
+    conn.commit()
+    conn.close()
+
+def save_sexaginta_score(user_id, display_name, game_info):
+    conn = sqlite3.connect(DB_NAME)
+    cursor = conn.cursor()
+    cursor.execute("""
+        INSERT INTO sexaginta_scores
+        (user_id, display_name, game_number, guesses_used, guesses_allowed, percent_solved, weighted_score, grid_text, created_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+    """, (
+        str(user_id),
+        display_name,
+        game_info.get("game_number"),
+        str(game_info.get("guesses_used")),
+        game_info.get("guesses_allowed"),
+        game_info.get("performance_pct"),
+        game_info.get("weighted_score"),
+        "\n".join(game_info.get("grid_lines", []))
+    ))
     conn.commit()
     conn.close()
 
@@ -568,6 +606,47 @@ def update_bandle_player_stats(user_id, display_name, attempts, bonus_rounds_com
         "total_plays": new_total_plays,
         "avg_attempts": new_avg_attempts,
         "avg_bonus_rounds": new_avg_bonus_rounds
+    }
+
+def update_sexaginta_stats(user_id, display_name, game_info):
+    """Update player stats for Sexaginta-quattuordle after a new score is submitted."""
+    conn = sqlite3.connect(DB_NAME)
+    cursor = conn.cursor()
+
+    cursor.execute("SELECT sexaginta_total_plays, sexaginta_avg_pct, sexaginta_avg_weighted_score FROM player_stats WHERE user_id = ?", (str(user_id),))
+    stats = cursor.fetchone()
+
+    if not stats or stats[0] is None:
+        total_plays, avg_pct, avg_weighted_score = 0, 0.0, 0.0
+        cursor.execute("SELECT user_id FROM player_stats WHERE user_id = ?", (str(user_id),))
+        if not cursor.fetchone():
+            cursor.execute("INSERT INTO player_stats (user_id, display_name) VALUES (?, ?)", (str(user_id), display_name))
+    else:
+        total_plays, avg_pct, avg_weighted_score = stats
+
+    performance_pct = game_info.get("performance_pct", 0)
+    weighted_score = game_info.get("weighted_score", 0)
+
+    new_total_plays = total_plays + 1
+    new_avg_pct = ((avg_pct * total_plays) + performance_pct) / new_total_plays
+    new_avg_weighted_score = ((avg_weighted_score * total_plays) + weighted_score) / new_total_plays
+
+    cursor.execute("""
+        UPDATE player_stats
+        SET display_name = ?,
+            sexaginta_total_plays = ?,
+            sexaginta_avg_pct = ?,
+            sexaginta_avg_weighted_score = ?
+        WHERE user_id = ?
+    """, (display_name, new_total_plays, new_avg_pct, new_avg_weighted_score, str(user_id)))
+
+    conn.commit()
+    conn.close()
+
+    return {
+        "total_plays": new_total_plays,
+        "avg_pct": new_avg_pct,
+        "avg_weighted_score": new_avg_weighted_score
     }
 
 def save_minute_cryptic_score(user_id: int, display_name: str, game_date: str, clue: str, word_length: int, score_description: str):
@@ -1011,6 +1090,66 @@ def get_word_salad_leaderboard(period: str = 'overall'):
     leaderboard = cursor.fetchall()
     conn.close()
     return leaderboard
+
+def get_sexaginta_leaderboard(period="weekly"):
+    conn = sqlite3.connect(DB_NAME)
+    cursor = conn.cursor()
+    where_clause, params = get_scores_by_period(period, "created_at")
+
+    # Top players
+    cursor.execute(f"""
+        SELECT display_name, AVG(percent_solved) as avg_pct, AVG(weighted_score) as avg_score, COUNT(*) as plays
+        FROM sexaginta_scores
+        {where_clause}
+        GROUP BY user_id, display_name
+        ORDER BY avg_pct DESC, avg_score DESC
+        LIMIT 10
+    """, params)
+    top_players = cursor.fetchall()
+
+    # Superlatives
+    # The Strategist: Player with the highest average weighted score.
+    cursor.execute(f"""
+        SELECT display_name, AVG(weighted_score) as avg_score
+        FROM sexaginta_scores
+        {where_clause}
+        GROUP BY user_id, display_name
+        HAVING COUNT(*) > 3
+        ORDER BY avg_score DESC
+        LIMIT 1
+    """, params)
+    strategist = cursor.fetchone()
+
+    # The Finisher: Player with the highest average percent solved.
+    cursor.execute(f"""
+        SELECT display_name, AVG(percent_solved) as avg_pct
+        FROM sexaginta_scores
+        {where_clause}
+        GROUP BY user_id, display_name
+        HAVING COUNT(*) > 3
+        ORDER BY avg_pct DESC
+        LIMIT 1
+    """, params)
+    finisher = cursor.fetchone()
+
+    # The Veteran: Player with the most plays.
+    cursor.execute(f"""
+        SELECT display_name, COUNT(*) as plays
+        FROM sexaginta_scores
+        {where_clause}
+        GROUP BY user_id, display_name
+        ORDER BY plays DESC
+        LIMIT 1
+    """, params)
+    veteran = cursor.fetchone()
+
+    conn.close()
+    return {
+        "top_players": top_players,
+        "strategist": strategist,
+        "finisher": finisher,
+        "veteran": veteran
+    }
 
 def get_pips_leaderboard(period: str = 'overall'):
     """Fetch Pips leaderboard data, supporting different periods and stats."""

--- a/embed_builder.py
+++ b/embed_builder.py
@@ -48,6 +48,51 @@ async def build_wordle_leaderboard_embed(title: str, leaderboard_data: dict, per
     embed.set_footer(text=emit_footer)
     return embed
 
+async def build_sexaginta_leaderboard_embed(title: str, leaderboard_data: dict, period: str, color: discord.Color) -> discord.Embed:
+    """
+    Builds a Discord embed for the enhanced Sexaginta-quattuordle leaderboard.
+    """
+    embed = discord.Embed(
+        title=title,
+        description=f"Period: {period.capitalize()}",
+        color=color
+    )
+
+    # Top Players
+    top_players = leaderboard_data.get("top_players")
+    if top_players:
+        medals = ["🥇", "🥈", "🥉"]
+        player_list = []
+        for i, (player, avg_pct, avg_score, plays) in enumerate(top_players):
+            player_list.append(f"{medals[i]} **{player}** - {avg_pct:.2f}% solved, {avg_score:.2f} avg score, {plays} plays")
+        embed.add_field(name="🏆 Top Players", value="\n".join(player_list), inline=False)
+    else:
+        embed.add_field(name="🏆 Top Players", value="No scores recorded for this period.", inline=False)
+
+    # Superlatives
+    superlatives = []
+    strategist = leaderboard_data.get("strategist")
+    if strategist:
+        player, avg_score = strategist
+        superlatives.append(f"🧠 The Strategist Award to **{player}** for the highest average weighted score of {avg_score:.2f}.")
+
+    finisher = leaderboard_data.get("finisher")
+    if finisher:
+        player, avg_pct = finisher
+        superlatives.append(f"✅ The Finisher Award to **{player}** for the highest average percent solved of {avg_pct:.2f}%.")
+
+    veteran = leaderboard_data.get("veteran")
+    if veteran:
+        player, plays = veteran
+        superlatives.append(f"🎖️ The Veteran Award to **{player}** for the most plays with {plays} games.")
+
+    if superlatives:
+        embed.add_field(name="✨ Superlatives", value="\n".join(superlatives), inline=False)
+
+    emit_footer = f"Posted: {discord.utils.utcnow().strftime('%Y-%m-%d')}"
+    embed.set_footer(text=emit_footer)
+    return embed
+
 async def build_gisnep_leaderboard_embed(title: str, leaderboard_data: dict, period: str, color: discord.Color) -> discord.Embed:
     """
     Builds a Discord embed for the enhanced Gisnep leaderboard.

--- a/game_config.py
+++ b/game_config.py
@@ -16,6 +16,7 @@ LEADERBOARD_KEY_MAPPINGS = {
     "Minute Cryptic": ["display_name", "games_played", "solved_count", "avg_score"],
     "Word Salad": ["display_name", "games_played", "avg_time", "best_time", "avg_hints", "total_score", "avg_score"],
     "Pips": ["display_name", "total_score", "games_played", "cookie_count"],
+    "Sexaginta": ["display_name", "avg_pct", "avg_score", "plays"],
 }
 
 # Game configurations dictionary
@@ -134,5 +135,21 @@ GAME_CONFIGS = {
         "create_acknowledgement": score_parser.create_pips_acknowledgement,
         "create_introduction": score_parser.create_pips_introduction,
         "game_number_key": "game_number"
+    },
+    "sexaginta": {
+        "name": "Sexaginta-Quattuordle",
+        "aliases": ["64ordle", "sexaginta"],
+        "is_game_message": score_parser.is_sexaginta_message,
+        "parse_function": score_parser.parse_sexaginta_score,
+        "save_score_function": database.save_sexaginta_score,
+        "get_leaderboard_function": database.get_sexaginta_leaderboard,
+        "embed_builder_function": embed_builder.build_sexaginta_leaderboard_embed,
+        "leaderboard_keys": LEADERBOARD_KEY_MAPPINGS["Sexaginta"],
+        "get_latest_game_number_function": database.get_latest_game_number_from_db,
+        "update_latest_game_number_function": database.update_latest_game_number_in_db,
+        "chat_channel_name": "64ordle-chat",
+        "player_role_name": "64ordle-player",
+        "game_number_key": "game_number",
+        "create_introduction": True
     }
 }

--- a/main_bot.py
+++ b/main_bot.py
@@ -61,11 +61,16 @@ def get_bandle_stats(user_id: int, user_name: str, game_info: dict) -> dict:
         game_info["attempts"], game_info["bonus_rounds_completed"]
     )
 
+def get_sexaginta_stats(user_id: int, user_name: str, game_info: dict) -> dict:
+    """Gets Sexaginta-quattuordle player stats."""
+    return database.update_sexaginta_stats(user_id, user_name, game_info)
+
 PLAYER_STATS_HANDLERS = {
     "wordle": get_wordle_stats,
     "connections": get_connections_stats,
     "gisnep": get_gisnep_stats,
     "bandle": get_bandle_stats,
+    "sexaginta": get_sexaginta_stats,
 }
 
 
@@ -126,6 +131,8 @@ async def on_message(message):
                     config["save_score_function"](message.author.id, message.author.display_name, game_info["game_number"], game_info["completion_time_seconds"], game_info["hints_used"], game_info["score"])
                 elif game_key == "pips":
                     config["save_score_function"](message.author.id, message.author.display_name, game_info["game_number"], game_info["difficulty"], game_info["completion_time"], game_info["score"], game_info["cookie"])
+                elif game_key == "sexaginta":
+                    config["save_score_function"](message.author.id, message.author.display_name, game_info)
 
                 # 3. Get player stats if a handler exists
                 if stats_handler := PLAYER_STATS_HANDLERS.get(game_key):
@@ -227,6 +234,7 @@ async def get_leaderboard_embed(game_key: str, period: str) -> Optional[discord.
         "Framed": discord.Color.red(), "Gisnep": discord.Color.blue(),
         "Bandle": discord.Color.gold(), "Minute Cryptic": discord.Color.dark_teal(),
         "Word Salad": discord.Color.green(), "Pips": discord.Color.orange(),
+        "Sexaginta-Quattuordle": discord.Color.dark_gold(),
     }
     color = game_colors.get(game_name, discord.Color.from_rgb(128, 128, 128))
     title = f"🏆 The {game_name} {period.capitalize()} Leaderboard 🏆"

--- a/post_generator.py
+++ b/post_generator.py
@@ -318,6 +318,37 @@ def _generate_framed_post(display_name: str, game_info: dict, player_stats: dict
 
     return opening_line
 
+def _generate_sexaginta_post(display_name: str, game_info: dict, player_stats: dict) -> str:
+    """
+    Generates dynamic but grounded feedback for 64ordle.
+    Highlights exceptional performances (high solve % or low guess count).
+    """
+    game_number = game_info.get("game_number", "?")
+    guesses_used = game_info.get("guesses_used", "?")
+    guesses_allowed = game_info.get("guesses_allowed", 70)
+    pct = game_info.get("pct") or game_info.get("performance_pct")
+    weighted_score = game_info.get("weighted_score")
+    band_counts = game_info.get("band_counts", {})
+
+    # --- Opening Line ---
+    if guesses_used == "X":
+        opening = f"😵 **{display_name}** couldn't tame Sexaginta-Quattuordle #{game_number} this time."
+    else:
+        opening = f"**{display_name}** finished #{game_number} in {guesses_used}/{guesses_allowed} guesses."
+
+    # --- Spotlight Conditions ---
+    spotlights = []
+    if pct is not None and pct >= 90:
+        spotlights.append(f"Only **{100-pct:.0f}%** left unsolved — stellar performance!")
+    if band_counts.get("red", 0) <= 3:
+        spotlights.append("Fewer than 4 reds — that's elite territory. 🔥")
+    if weighted_score and pct and pct < 50:
+        spotlights.append("A tough day — less than half solved, but a valiant effort.")
+
+    if spotlights:
+        return f"{opening}\n{random.choice(spotlights)}"
+    return opening
+
 def generate_post(game_name: str, display_name: str, game_info: dict, player_stats: dict) -> str:
     """Routes the request to the appropriate sub-generator for the given game."""
 
@@ -327,7 +358,8 @@ def generate_post(game_name: str, display_name: str, game_info: dict, player_sta
         "gisnep": _generate_gisnep_post,
         "bandle": _generate_bandle_post,
         "word_salad": _generate_word_salad_post,
-        "framed": _generate_framed_post, # <-- ADD THIS LINE
+        "framed": _generate_framed_post,
+        "sexaginta": _generate_sexaginta_post,
     }
 
     generator_func = game_generators.get(game_name.lower())

--- a/score_parser.py
+++ b/score_parser.py
@@ -20,6 +20,79 @@ WORD_SALAD_TIME_PATTERN = re.compile(r"⌛(\d+m\s*\d+s)", re.IGNORECASE)
 WORD_SALAD_HINTS_PATTERN = re.compile(r"❓(\d+)", re.IGNORECASE)
 PIPS_PATTERN = re.compile(r"Pips\s+#(\d+)\s+(Easy|Medium|Hard)\s+(?:🟢|🟡|🔴)\s*\n(\d{1,2}:\d{2})\s*(🍪)?", re.IGNORECASE)
 
+SEXAGINTA_HEADER_RE = re.compile(
+    r"#SexagintaQuattuordle\s+(\d+)\s+(\d{1,2}|X)\/(\d{1,2})\s*(?:\(score\s*([\d,]+)\s*,\s*([\d]{1,3})%\))?",
+    re.IGNORECASE
+)
+
+# Emoji band mapping
+SEXAGINTA_BANDS = {
+    "purple": {"💜","🟪","🟣"},
+    "blue":   {"💙","🟦","🔵"},
+    "green":  {"💚","🟩","🟢"},
+    "yellow": {"💛","🟨","🟡"},
+    "orange": {"🧡","🟧","🟠"},
+    "red":    {"❤️","🟥","🔴","❌"},
+}
+
+SEXAGINTA_BAND_WEIGHTS = {
+    "purple": 6,
+    "blue": 5,
+    "green": 4,
+    "yellow": 3,
+    "orange": 2,
+    "red": 1
+}
+
+def parse_sexaginta_score(text: str, author_id: int = None) -> Optional[Dict[str, Any]]:
+    header_match = SEXAGINTA_HEADER_RE.search(text)
+    if not header_match:
+        return None
+
+    game_number = int(header_match.group(1))
+    guesses_used = header_match.group(2)
+    guesses_allowed = int(header_match.group(3))
+    score_value = int(header_match.group(4).replace(",", "")) if header_match.group(4) else None
+    percent_solved = int(header_match.group(5)) if header_match.group(5) else None
+
+    # Extract seed from URL
+    seed_match = re.search(r"https://64ordle\.au/\?seed=(\d+)", text)
+    seed = int(seed_match.group(1)) if seed_match else None
+
+    lines = text.split('\n')
+    grid_lines: List[str] = []
+    for ln in lines:
+        if any(ch in ln for ch in ("🟪","🟦","🟩","🟨","🟧","🟥","💜","💙","💚","💛","🧡","❤️","🔵","🔴","❌")):
+            grid_lines.append(ln)
+
+    # --- Advanced band parsing ---
+    band_counts = {band: 0 for band in SEXAGINTA_BANDS.keys()}
+    for row in grid_lines:
+        for ch in row:
+            for band, symbols in SEXAGINTA_BANDS.items():
+                if ch in symbols:
+                    band_counts[band] += 1
+                    break
+
+    # Calculate weighted performance score
+    weighted_score = sum(SEXAGINTA_BAND_WEIGHTS[b] * c for b, c in band_counts.items())
+    max_score = 64 * SEXAGINTA_BAND_WEIGHTS["purple"]
+    performance_pct = (weighted_score / max_score) * 100 if max_score else None
+
+    return {
+        "game_number": game_number,
+        "guesses_used": guesses_used,
+        "guesses_allowed": guesses_allowed,
+        "score_value": score_value,
+        "pct": percent_solved,
+        "grid_lines": grid_lines,
+        "seed": seed,
+        "band_counts": band_counts,
+        "weighted_score": weighted_score,
+        "performance_pct": round(performance_pct, 1) if performance_pct is not None else None,
+        "author_id": author_id
+    }
+
 def parse_wordle_score(message_content: str) -> Optional[Dict[str, Any]]:
     wordle_match = WORDLE_PATTERN.search(message_content)
     skill_luck_match = SKILL_LUCK_PATTERN.search(message_content)
@@ -136,6 +209,7 @@ def parse_connections_result(message_content: str) -> Optional[Dict[str, Any]]:
         "solve_order": solve_order,
         "rainbow_wrong_guess": rainbow_wrong_guess,
         "guesses": all_guesses, # Now contains actual guess content
+        "num_guesses": len(all_guesses)
     }
 
 def calculate_connections_score(guesses, found_colors, first_successful, mistake_count, skill_score=None):
@@ -513,6 +587,10 @@ def is_word_salad_message(message_content: str) -> bool:
 def is_pips_message(message_content: str) -> bool:
     """Checks if a message contains a Pips score."""
     return "pips #" in message_content.lower() and PIPS_PATTERN.search(message_content) is not None
+
+def is_sexaginta_message(message_content: str) -> bool:
+    """Checks if a message contains a Sexaginta-quattuordle score."""
+    return "sexagintaquattuordle" in message_content.lower() and SEXAGINTA_HEADER_RE.search(message_content) is not None
     
 def create_wordle_acknowledgement(display_name: str, game_info: Dict[str, Any]) -> str:
     return "🤖"

--- a/test_score_parser.py
+++ b/test_score_parser.py
@@ -263,6 +263,12 @@ Full parsed object:
             parsefn = score_parser.parse_bandle_score,
             matchfields = ['game_number', 'attempts', 'solved', 'bonus_rounds_completed', 'bonus_rounds_total', 'bonus_emojis', 'current_streak', 'max_streak', 'total_score'])
 
+    def test_parse_sexaginta_score(self):
+        self.do_parse_test(
+            sheet = self.sheets['Sexaginta'],
+            parsefn = score_parser.parse_sexaginta_score,
+            matchfields = ['game_number', 'guesses_used', 'guesses_allowed', 'score_value', 'pct', 'seed', 'weighted_score', 'performance_pct'])
+
 class TestPipsParser(unittest.TestCase):
     def test_calculate_pips_score(self):
         # Test cases for easy difficulty


### PR DESCRIPTION
This commit adds full support for the game Sexaginta-Quattuordle (64ordle).

- Adds a new parser for the game's score posts, including advanced parsing of emoji bands to calculate a weighted score.
- Creates a new `sexaginta_scores` table in the database to store game results and adds columns to the `player_stats` table to track player performance.
- Implements a new post generator that provides dynamic feedback on player performance.
- Adds a leaderboard with superlatives for the game.
- Includes a new test case and example data to ensure the parser works correctly.