### PR TITLE
fix: Correct Sexaginta embed builder configuration

### DIFF
--- a/game_config.py
+++ b/game_config.py
@@ -143,7 +143,7 @@ GAME_CONFIGS = {
         "parse_function": score_parser.parse_sexaginta_score,
         "save_score_function": database.save_sexaginta_score,
         "get_leaderboard_function": database.get_sexaginta_leaderboard,
-        "embed_builder_function": embed_builder.build_sexaginta_leaderboard_embed,
+        "embed_builder_function": embed_builder.build_leaderboard_embed,
         "leaderboard_keys": LEADERBOARD_KEY_MAPPINGS["Sexaginta"],
         "get_latest_game_number_function": database.get_latest_game_number_from_db,
         "update_latest_game_number_function": database.update_latest_game_number_in_db,


### PR DESCRIPTION
This commit fixes an `AttributeError` that occurred when trying to build the Sexaginta leaderboard. The error was caused by a missing `build_sexaginta_leaderboard_embed` function in `embed_builder.py`.

The fix involves updating `game_config.py` to point the `embed_builder_function` for the `sexaginta` game to the existing generic `embed_builder.build_leaderboard_embed` function. This generic function already contains custom logic to handle the Sexaginta leaderboard, so no new function implementation was needed.