### PR TITLE
Fix Word Salad score parsing and add tests

### DIFF
--- a/Minigame Scores Examples.fods
+++ b/Minigame Scores Examples.fods
@@ -1004,6 +1004,81 @@
      <table:table-cell table:number-columns-repeated="1024"/>
     </table:table-row>
    </table:table>
+   <table:table table:name="Word Salad" table:style-name="ta1">
+    <table:table-column table:style-name="co1" table:default-cell-style-name="Default"/>
+    <table:table-column table:style-name="co2" table:default-cell-style-name="Default"/>
+    <table:table-column table:style-name="co3" table:default-cell-style-name="Default"/>
+    <table:table-column table:style-name="co2" table:number-columns-repeated="1021" table:default-cell-style-name="Default"/>
+    <table:table-row table:style-name="ro1">
+     <table:table-cell table:style-name="ce7" office:value-type="string" calcext:value-type="string">
+      <text:p>share_text</text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="ce7" office:value-type="string" calcext:value-type="string">
+      <text:p>game_number</text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="ce7" office:value-type="string" calcext:value-type="string">
+      <text:p>completion_time_seconds</text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="ce7" office:value-type="string" calcext:value-type="string">
+      <text:p>hints_used</text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="ce7" office:value-type="string" calcext:value-type="string">
+      <text:p>score</text:p>
+     </table:table-cell>
+     <table:table-cell table:number-columns-repeated="1019"/>
+    </table:table-row>
+    <table:table-row table:style-name="ro3">
+     <table:table-cell table:style-name="ce7" office:value-type="string" calcext:value-type="string"><text:p>Word Salad #568</text:p><text:p>Edible Roots</text:p><text:p>⌛1m 20s, ❓0</text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="ce7" office:value-type="float" office:value="568" calcext:value-type="float">
+      <text:p>568</text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="ce7" office:value-type="float" office:value="80" calcext:value-type="float">
+      <text:p>80</text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="ce7" office:value-type="float" office:value="0" calcext:value-type="float">
+      <text:p>0</text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="ce7" office:value-type="float" office:value="15" calcext:value-type="float">
+      <text:p>15</text:p>
+     </table:table-cell>
+     <table:table-cell table:number-columns-repeated="1019"/>
+    </table:table-row>
+    <table:table-row table:style-name="ro3">
+     <table:table-cell table:style-name="ce7" office:value-type="string" calcext:value-type="string"><text:p>Word Salad #569</text:p><text:p>Some Theme</text:p><text:p>⌛2m, ❓1</text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="ce7" office:value-type="float" office:value="569" calcext:value-type="float">
+      <text:p>569</text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="ce7" office:value-type="float" office:value="120" calcext:value-type="float">
+      <text:p>120</text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="ce7" office:value-type="float" office:value="1" calcext:value-type="float">
+      <text:p>1</text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="ce7" office:value-type="float" office:value="9" calcext:value-type="float">
+      <text:p>9</text:p>
+     </table:table-cell>
+     <table:table-cell table:number-columns-repeated="1019"/>
+    </table:table-row>
+    <table:table-row table:style-name="ro3">
+     <table:table-cell table:style-name="ce7" office:value-type="string" calcext:value-type="string"><text:p>Word Salad #570</text:p><text:p>Another Theme</text:p><text:p>⌛55s, ❓2</text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="ce7" office:value-type="float" office:value="570" calcext:value-type="float">
+      <text:p>570</text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="ce7" office:value-type="float" office:value="55" calcext:value-type="float">
+      <text:p>55</text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="ce7" office:value-type="float" office:value="2" calcext:value-type="float">
+      <text:p>2</text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="ce7" office:value-type="float" office:value="16" calcext:value-type="float">
+      <text:p>16</text:p>
+     </table:table-cell>
+     <table:table-cell table:number-columns-repeated="1019"/>
+    </table:table-row>
+   </table:table>
    <table:named-expressions/>
   </office:spreadsheet>
  </office:body>

--- a/score_parser.py
+++ b/score_parser.py
@@ -19,7 +19,6 @@ WORD_SALAD_NUMBER_PATTERN = re.compile(
     r"Word\s+Salad\s*#\s*(\d+)",   # any whitespace before/after “#”
     re.IGNORECASE
 )
-WORD_SALAD_TIME_PATTERN = re.compile(r"⌛(\d+m\s*\d+s)", re.IGNORECASE)
 WORD_SALAD_HINTS_PATTERN = re.compile(r"❓(\d+)", re.IGNORECASE)
 PIPS_PATTERN = re.compile(r"Pips\s+#(\d+)\s+(Easy|Medium|Hard)\s+(?:🟢|🟡|🔴)\s*\n(\d{1,2}:\d{2})\s*(🍪)?", re.IGNORECASE)
 
@@ -418,12 +417,28 @@ def parse_word_salad_score(message_content: str) -> Optional[Dict[str, Any]]:
     game_number = int(puzzle_match.group(1))
     print(f"DEBUG: Game number found: {game_number}")
 
-    time_match = re.search(r"⌛(\d+)m\s*(\d+)s", message_content)
-    if not time_match:
-        print("DEBUG: Failed to match 'Time' pattern (e.g., '⌛0m 43s').")
+    time_str_match = re.search(r"⌛([^,\n]+)", message_content)
+    if not time_str_match:
+        print("DEBUG: Failed to match time string pattern.")
         return None
-    minutes = int(time_match.group(1))
-    seconds = int(time_match.group(2))
+
+    time_str = time_str_match.group(1).strip()
+
+    minutes = 0
+    seconds = 0
+
+    minutes_match = re.search(r"(\d+)m", time_str)
+    if minutes_match:
+        minutes = int(minutes_match.group(1))
+
+    seconds_match = re.search(r"(\d+)s", time_str)
+    if seconds_match:
+        seconds = int(seconds_match.group(1))
+
+    if minutes == 0 and seconds == 0:
+        print(f"DEBUG: No minutes or seconds found in time string: {time_str}")
+        return None
+
     completion_time_seconds = minutes * 60 + seconds
     print(f"DEBUG: Time found: {minutes}m {seconds}s ({completion_time_seconds} seconds)")
 

--- a/test_score_parser.py
+++ b/test_score_parser.py
@@ -277,6 +277,12 @@ Full parsed object:
             parsefn = score_parser.parse_sexaginta_score,
             matchfields = ['game_number', 'game_score', 'performance_pct', 'seed'])
 
+    def test_parse_word_salad_score(self):
+        self.do_parse_test(
+            sheet = self.sheets['Word Salad'],
+            parsefn = score_parser.parse_word_salad_score,
+            matchfields = ['game_number', 'completion_time_seconds', 'hints_used', 'score'])
+
 class TestPipsParser(unittest.TestCase):
     def test_calculate_pips_score(self):
         # Test cases for easy difficulty


### PR DESCRIPTION
The Word Salad score parser was failing to parse scores with various time formats. The time parsing regex was too strict and could not handle cases where only minutes or only seconds were present.

This change:
- Updates the `parse_word_salad_score` function in `score_parser.py` with a more robust time parsing logic.
- Adds a new "Word Salad" sheet to `Minigame Scores Examples.fods` with test cases covering different time formats.
- Adds a new test method `test_parse_word_salad_score` to `test_score_parser.py` to verify the fix.