### PR TITLE
feat: Enable introductions for Bandle and Framed

### DIFF
--- a/game_config.py
+++ b/game_config.py
@@ -74,6 +74,7 @@ GAME_CONFIGS = {
         "embed_builder_function": embed_builder.build_leaderboard_embed,
         "get_latest_game_number_function": database.get_latest_game_number_from_db,
         "update_latest_game_number_function": database.update_latest_game_number_in_db,
+        "create_introduction": score_parser.create_framed_introduction,
         "game_number_key": "game_number"
     },
     "bandle": {
@@ -88,6 +89,7 @@ GAME_CONFIGS = {
         "embed_builder_function": embed_builder.build_leaderboard_embed,
         "get_latest_game_number_function": database.get_latest_game_number_from_db,
         "update_latest_game_number_function": database.update_latest_game_number_in_db,
+        "create_introduction": score_parser.create_bandle_introduction,
         "game_number_key": "game_number"
     },
     "minute_cryptic": {


### PR DESCRIPTION
Adds the 'create_introduction' key to the game configurations for Bandle and Framed in game_config.py.

This change enables the existing introduction and role logic for these games, which was previously not being triggered due to the missing configuration.