### PR TITLE
Refactor game introductions to use post_generator

### DIFF
--- a/database.py
+++ b/database.py
@@ -40,7 +40,23 @@ def initialize_db():
                 gisnep_personal_best_seconds INTEGER, -- Can be NULL
                 sexaginta_total_plays INTEGER DEFAULT 0,
                 sexaginta_avg_pct REAL DEFAULT 0.0,
-                sexaginta_avg_game_score REAL DEFAULT 0.0
+                sexaginta_avg_game_score REAL DEFAULT 0.0,
+                framed_total_plays INTEGER DEFAULT 0,
+                framed_total_wins INTEGER DEFAULT 0,
+                framed_current_streak INTEGER DEFAULT 0,
+                framed_max_streak INTEGER DEFAULT 0,
+                framed_avg_attempts REAL DEFAULT 0.0,
+                framed_avg_score REAL DEFAULT 0.0,
+                word_salad_total_plays INTEGER DEFAULT 0,
+                word_salad_avg_time REAL DEFAULT 0.0,
+                word_salad_personal_best_time INTEGER,
+                word_salad_avg_hints REAL DEFAULT 0.0,
+                word_salad_avg_score REAL DEFAULT 0.0,
+                minute_cryptic_total_plays INTEGER DEFAULT 0,
+                minute_cryptic_solved INTEGER DEFAULT 0,
+                minute_cryptic_avg_score REAL DEFAULT 0.0,
+                pips_total_score INTEGER DEFAULT 0,
+                pips_total_cookies INTEGER DEFAULT 0
             )
         """)
         # Connections
@@ -652,6 +668,199 @@ def update_sexaginta_stats(user_id, display_name, game_info):
         "total_plays": new_total_plays,
         "avg_pct": new_avg_pct,
         "avg_game_score": new_avg_game_score
+    }
+
+def update_framed_player_stats(user_id, display_name, game_info):
+    """Update player stats for Framed after a new score is submitted."""
+    conn = sqlite3.connect(DB_NAME)
+    cursor = conn.cursor()
+
+    cursor.execute("SELECT framed_total_plays, framed_total_wins, framed_current_streak, framed_max_streak, framed_avg_attempts, framed_avg_score FROM player_stats WHERE user_id = ?", (str(user_id),))
+    stats = cursor.fetchone()
+
+    if not stats or stats[0] is None:
+        total_plays, total_wins, current_streak, max_streak, avg_attempts, avg_score = 0, 0, 0, 0, 0.0, 0.0
+        cursor.execute("SELECT user_id FROM player_stats WHERE user_id = ?", (str(user_id),))
+        if not cursor.fetchone():
+            cursor.execute("INSERT INTO player_stats (user_id, display_name) VALUES (?, ?)", (str(user_id), display_name))
+    else:
+        total_plays, total_wins, current_streak, max_streak, avg_attempts, avg_score = stats
+
+    # --- Calculate new stats ---
+    new_total_plays = total_plays + 1
+    was_a_win = game_info.get("solved", False)
+    new_total_wins = total_wins + (1 if was_a_win else 0)
+
+    if was_a_win:
+        new_streak = current_streak + 1
+    else:
+        new_streak = 0
+
+    new_max_streak = max(max_streak, new_streak)
+
+    attempts = game_info.get("attempts", 7)
+    new_avg_attempts = ((avg_attempts * total_plays) + attempts) / new_total_plays if new_total_plays > 0 else float(attempts)
+
+    score = game_info.get("total_score", 0)
+    new_avg_score = ((avg_score * total_plays) + score) / new_total_plays if new_total_plays > 0 else float(score)
+
+    cursor.execute("""
+        UPDATE player_stats
+        SET display_name = ?, framed_total_plays = ?, framed_total_wins = ?, framed_current_streak = ?, framed_max_streak = ?, framed_avg_attempts = ?, framed_avg_score = ?
+        WHERE user_id = ?
+    """, (display_name, new_total_plays, new_total_wins, new_streak, new_max_streak, new_avg_attempts, new_avg_score, str(user_id)))
+
+    conn.commit()
+    conn.close()
+
+    return {
+        "total_plays": new_total_plays,
+        "total_wins": new_total_wins,
+        "current_streak": new_streak,
+        "max_streak": new_max_streak,
+        "is_new_max_streak": new_streak > max_streak and new_streak > 1,
+        "avg_attempts": new_avg_attempts,
+        "avg_score": new_avg_score
+    }
+
+def update_word_salad_player_stats(user_id, display_name, game_info):
+    """Update player stats for Word Salad after a new score is submitted."""
+    conn = sqlite3.connect(DB_NAME)
+    cursor = conn.cursor()
+
+    cursor.execute("SELECT word_salad_total_plays, word_salad_avg_time, word_salad_personal_best_time, word_salad_avg_hints, word_salad_avg_score FROM player_stats WHERE user_id = ?", (str(user_id),))
+    stats = cursor.fetchone()
+
+    if not stats or stats[0] is None:
+        total_plays, avg_time, personal_best, avg_hints, avg_score = 0, 0.0, None, 0.0, 0.0
+        cursor.execute("SELECT user_id FROM player_stats WHERE user_id = ?", (str(user_id),))
+        if not cursor.fetchone():
+            cursor.execute("INSERT INTO player_stats (user_id, display_name) VALUES (?, ?)", (str(user_id), display_name))
+    else:
+        total_plays, avg_time, personal_best, avg_hints, avg_score = stats
+
+    total_plays = total_plays or 0
+    avg_time = avg_time or 0.0
+    avg_hints = avg_hints or 0.0
+    avg_score = avg_score or 0.0
+
+    new_total_plays = total_plays + 1
+
+    time_seconds = game_info.get("completion_time_seconds", 0)
+    new_avg_time = ((avg_time * total_plays) + time_seconds) / new_total_plays if new_total_plays > 0 else float(time_seconds)
+
+    is_new_pb = False
+    if personal_best is None or time_seconds < personal_best:
+        personal_best = time_seconds
+        is_new_pb = True
+
+    hints = game_info.get("hints_used", 0)
+    new_avg_hints = ((avg_hints * total_plays) + hints) / new_total_plays if new_total_plays > 0 else float(hints)
+
+    score = game_info.get("score", 0)
+    new_avg_score = ((avg_score * total_plays) + score) / new_total_plays if new_total_plays > 0 else float(score)
+
+    cursor.execute("""
+        UPDATE player_stats
+        SET display_name = ?, word_salad_total_plays = ?, word_salad_avg_time = ?, word_salad_personal_best_time = ?, word_salad_avg_hints = ?, word_salad_avg_score = ?
+        WHERE user_id = ?
+    """, (display_name, new_total_plays, new_avg_time, personal_best, new_avg_hints, new_avg_score, str(user_id)))
+
+    conn.commit()
+    conn.close()
+
+    return {
+        "total_plays": new_total_plays,
+        "avg_time": new_avg_time,
+        "is_new_pb": is_new_pb,
+        "personal_best": personal_best,
+        "avg_hints": new_avg_hints,
+        "avg_score": new_avg_score
+    }
+
+def update_minute_cryptic_player_stats(user_id, display_name, game_info):
+    """Update player stats for Minute Cryptic after a new score is submitted."""
+    conn = sqlite3.connect(DB_NAME)
+    cursor = conn.cursor()
+
+    cursor.execute("SELECT minute_cryptic_total_plays, minute_cryptic_solved, minute_cryptic_avg_score FROM player_stats WHERE user_id = ?", (str(user_id),))
+    stats = cursor.fetchone()
+
+    if not stats or stats[0] is None:
+        total_plays, solved_count, avg_score = 0, 0, 0.0
+        cursor.execute("SELECT user_id FROM player_stats WHERE user_id = ?", (str(user_id),))
+        if not cursor.fetchone():
+            cursor.execute("INSERT INTO player_stats (user_id, display_name) VALUES (?, ?)", (str(user_id), display_name))
+    else:
+        total_plays, solved_count, avg_score = stats
+
+    total_plays = total_plays or 0
+    solved_count = solved_count or 0
+    avg_score = avg_score or 0.0
+
+    new_total_plays = total_plays + 1
+
+    was_solved = game_info.get("solved", False)
+    new_solved_count = solved_count + (1 if was_solved else 0)
+
+    score = game_info.get("score_value", 0)
+    new_avg_score = ((avg_score * total_plays) + score) / new_total_plays if new_total_plays > 0 else float(score)
+
+    cursor.execute("""
+        UPDATE player_stats
+        SET display_name = ?, minute_cryptic_total_plays = ?, minute_cryptic_solved = ?, minute_cryptic_avg_score = ?
+        WHERE user_id = ?
+    """, (display_name, new_total_plays, new_solved_count, new_avg_score, str(user_id)))
+
+    conn.commit()
+    conn.close()
+
+    return {
+        "total_plays": new_total_plays,
+        "solved_count": new_solved_count,
+        "avg_score": new_avg_score
+    }
+
+def update_pips_player_stats(user_id, display_name, game_info):
+    """Update player stats for Pips after a new score is submitted."""
+    conn = sqlite3.connect(DB_NAME)
+    cursor = conn.cursor()
+
+    cursor.execute("SELECT pips_total_score, pips_total_cookies FROM player_stats WHERE user_id = ?", (str(user_id),))
+    stats = cursor.fetchone()
+
+    if not stats or stats[0] is None:
+        total_score, total_cookies = 0, 0
+        cursor.execute("SELECT user_id FROM player_stats WHERE user_id = ?", (str(user_id),))
+        if not cursor.fetchone():
+            cursor.execute("INSERT INTO player_stats (user_id, display_name) VALUES (?, ?)", (str(user_id), display_name))
+    else:
+        total_score, total_cookies = stats
+
+    total_score = total_score or 0
+    total_cookies = total_cookies or 0
+
+    new_total_score = total_score + game_info.get("score", 0)
+    new_total_cookies = total_cookies + (1 if game_info.get("cookie", False) else 0)
+
+    cursor.execute("""
+        UPDATE player_stats
+        SET display_name = ?, pips_total_score = ?, pips_total_cookies = ?
+        WHERE user_id = ?
+    """, (display_name, new_total_score, new_total_cookies, str(user_id)))
+
+    conn.commit()
+
+    # For pips, we also need to fetch all scores for the current game to generate the post.
+    game_number = game_info.get("game_number")
+    scores = get_pips_scores_for_game(user_id, game_number)
+
+    conn.close()
+
+    return {
+        "total_score": new_total_score,
+        "total_cookies": new_total_cookies,
+        "scores": [dict(row) for row in scores]
     }
     
 def save_minute_cryptic_score(user_id: int, display_name: str, game_date: str, clue: str, word_length: int, score_description: str):

--- a/game_config.py
+++ b/game_config.py
@@ -74,7 +74,6 @@ GAME_CONFIGS = {
         "embed_builder_function": embed_builder.build_leaderboard_embed,
         "get_latest_game_number_function": database.get_latest_game_number_from_db,
         "update_latest_game_number_function": database.update_latest_game_number_in_db,
-        "create_introduction": score_parser.create_framed_introduction,
         "game_number_key": "game_number"
     },
     "bandle": {
@@ -89,7 +88,6 @@ GAME_CONFIGS = {
         "embed_builder_function": embed_builder.build_leaderboard_embed,
         "get_latest_game_number_function": database.get_latest_game_number_from_db,
         "update_latest_game_number_function": database.update_latest_game_number_in_db,
-        "create_introduction": score_parser.create_bandle_introduction,
         "game_number_key": "game_number"
     },
     "minute_cryptic": {
@@ -105,7 +103,6 @@ GAME_CONFIGS = {
         "get_latest_game_number_function": database.get_latest_minute_cryptic_date,
         "update_latest_game_number_function": database.update_latest_minute_cryptic_date,
         "create_acknowledgement": score_parser.create_minute_cryptic_acknowledgement,
-        "create_introduction": score_parser.create_minute_cryptic_introduction,
         "game_number_key": "game_date"
     },
     "word_salad": {
@@ -135,7 +132,6 @@ GAME_CONFIGS = {
         "get_latest_game_number_function": database.get_latest_game_number_from_db,
         "update_latest_game_number_function": database.update_latest_game_number_in_db,
         "create_acknowledgement": score_parser.create_pips_acknowledgement,
-        "create_introduction": score_parser.create_pips_introduction,
         "game_number_key": "game_number"
     },
     "sexaginta": {

--- a/main_bot.py
+++ b/main_bot.py
@@ -66,12 +66,32 @@ def get_sexaginta_stats(user_id: int, user_name: str, game_info: dict) -> dict:
     """Gets Sexaginta-quattuordle player stats."""
     return database.update_sexaginta_stats(user_id, user_name, game_info)
 
+def get_framed_stats(user_id: int, user_name: str, game_info: dict) -> dict:
+    """Gets Framed player stats."""
+    return database.update_framed_player_stats(user_id, user_name, game_info)
+
+def get_word_salad_stats(user_id: int, user_name: str, game_info: dict) -> dict:
+    """Gets Word Salad player stats."""
+    return database.update_word_salad_player_stats(user_id, user_name, game_info)
+
+def get_minute_cryptic_stats(user_id: int, user_name: str, game_info: dict) -> dict:
+    """Gets Minute Cryptic player stats."""
+    return database.update_minute_cryptic_player_stats(user_id, user_name, game_info)
+
+def get_pips_stats(user_id: int, user_name: str, game_info: dict) -> dict:
+    """Gets Pips player stats."""
+    return database.update_pips_player_stats(user_id, user_name, game_info)
+
 PLAYER_STATS_HANDLERS = {
     "wordle": get_wordle_stats,
     "connections": get_connections_stats,
     "gisnep": get_gisnep_stats,
     "bandle": get_bandle_stats,
     "sexaginta": get_sexaginta_stats,
+    "framed": get_framed_stats,
+    "word_salad": get_word_salad_stats,
+    "minute_cryptic": get_minute_cryptic_stats,
+    "pips": get_pips_stats,
 }
 
 
@@ -169,13 +189,17 @@ async def on_message(message):
                     config, current_game_identifier, latest_game_identifier
                 )
 
-                if should_introduce and config.get("create_introduction"):
-                    await role_manager.introduce_player_in_game_channel(
-                        message.guild,
-                        message.author,
-                        config,
-                        game_info
-                    )
+                post_message = post_generator.generate_post(
+                    game_key,
+                    message.author.display_name,
+                    game_info,
+                    player_stats
+                )
+
+                # For Pips, the introduction is only posted when all difficulties are complete.
+                # The should_introduce flag from handle_game_role_assignment tells us when this happens.
+                if game_key == 'pips' and not should_introduce:
+                    post_message = None
 
                 if not post_message and config.get("create_acknowledgement"):
                     acknowledgement = config["create_acknowledgement"](message.author.display_name, game_info)

--- a/post_generator.py
+++ b/post_generator.py
@@ -349,6 +349,57 @@ def _generate_sexaginta_post(display_name: str, game_info: dict, player_stats: d
     
     return f"{opening}\n{random.choice(starters)}"
 
+def _generate_minute_cryptic_post(display_name: str, game_info: dict, player_stats: dict) -> str:
+    """Generates a dynamic post for Minute Cryptic scores."""
+    game_date = game_info.get("game_date", "a recent puzzle")
+    score_desc = game_info.get("score_description", "a score")
+    solved = game_info.get("solved", False)
+
+    if solved:
+        opening_line = f"🕵️‍♀️ A clever solve! **{display_name}** cracked the Minute Cryptic for {game_date}."
+    else:
+        opening_line = f"🤔 That was a tricky one! **{display_name}** tackled the Minute Cryptic for {game_date}."
+
+    spotlights = []
+    if solved:
+        spotlights.append(f"Their final score was **{score_desc}**.")
+
+    avg_score = player_stats.get("avg_score")
+    if avg_score is not None:
+        spotlights.append(f"Their average score is now **{avg_score:.2f}**.")
+
+    if not spotlights:
+        spotlights.append("Another puzzle in the books!")
+
+    return f"{opening_line}\n{random.choice(spotlights)}"
+
+def _generate_pips_post(display_name: str, game_info: dict, player_stats: dict) -> str:
+    """Generates a post for a completed Pips game."""
+    game_number = game_info.get("game_number", "?")
+    scores = player_stats.get("scores")
+
+    if not scores:
+        return f"🏆 **{display_name}** is making progress on Pips #{game_number}!"
+
+    total_score = sum(s['score'] for s in scores)
+    cookie_count = sum(s['cookie'] for s in scores)
+
+    message = f"🏆 **{display_name}** has completed all Pips difficulties for game #{game_number} with a total score of **{total_score}**!\n\n"
+
+    for score in scores:
+        time_min = score['completion_time'] // 60
+        time_sec = score['completion_time'] % 60
+        time_str = f"{time_min}:{time_sec:02d}"
+        message += f"**{score['difficulty'].capitalize()}**: {time_str} ({score['score']} pts)"
+        if score.get('cookie'):
+            message += " 🍪"
+        message += "\n"
+
+    if cookie_count > 0:
+        message += f"\nWow, {cookie_count} cookie{'s' if cookie_count > 1 else ''}! You're a top performer! 🍪"
+
+    return message
+
 def generate_post(game_name: str, display_name: str, game_info: dict, player_stats: dict) -> str:
     """Routes the request to the appropriate sub-generator for the given game."""
 
@@ -360,6 +411,8 @@ def generate_post(game_name: str, display_name: str, game_info: dict, player_sta
         "word_salad": _generate_word_salad_post,
         "framed": _generate_framed_post,
         "sexaginta": _generate_sexaginta_post,
+        "minute_cryptic": _generate_minute_cryptic_post,
+        "pips": _generate_pips_post,
     }
 
     generator_func = game_generators.get(game_name.lower())

--- a/role_manager.py
+++ b/role_manager.py
@@ -105,23 +105,3 @@ async def handle_game_role_assignment(
     
     # For other games, introduction is based on posting a new or same score.
     return True
-
-async def introduce_player_in_game_channel(
-    guild: discord.Guild,
-    member: discord.Member,
-    game_config: Dict[str, Any],
-    game_info: Dict[str, Any]
-) -> None:
-    channel_name = game_config["chat_channel_name"]
-    game_channel = discord.utils.get(guild.text_channels, name=channel_name)
-    
-    if not game_channel:
-        print(f"Could not find {channel_name} channel")
-        return
-
-    # Add user_id to game_info so all games can fetch more data for the intro message
-    game_info['user_id'] = member.id
-    
-    intro_message = game_config["create_introduction"](member.display_name, game_info)
-    await game_channel.send(intro_message)
-    print(f"Introduction posted for {member.display_name} in #{channel_name}")

--- a/score_parser.py
+++ b/score_parser.py
@@ -1,7 +1,6 @@
 import re
 from typing import Dict, List, Tuple, Optional, Any, Union
 from datetime import datetime, timedelta, date
-import database
 
 # Regular expressions for game patterns
 WORDLE_PATTERN = re.compile(r'Wordle\s+(?:#?\s*)(\d+(?:,\d+)?)\s+([0-6X])/6(\*?)', re.IGNORECASE)
@@ -19,7 +18,7 @@ PIPS_PATTERN = re.compile(r"Pips\s+#(\d+)\s+(Easy|Medium|Hard)\s+(?:🟢|🟡|�
 
 WORD_SALAD_FULL_PATTERN = re.compile(
     r".*?Word Salad #(\d+).*?"
-    r"⌛(\d+)m\s*(\d+)s.*?"
+    r"⌛\s*(?:(\d+)\s*m)?(?:,?\s*)?(?:(\d+)\s*s)?.*?"
     r"❓(\d+)",
     re.IGNORECASE | re.DOTALL
 )
@@ -403,10 +402,13 @@ def parse_word_salad_score(message_content: str) -> Optional[Dict[str, Any]]:
         return None
 
     game_number = int(full_match.group(1))
-    minutes = int(full_match.group(2))
-    seconds = int(full_match.group(3))
+    minutes = int(full_match.group(2)) if full_match.group(2) else 0
+    seconds = int(full_match.group(3)) if full_match.group(3) else 0
     hints_used = int(full_match.group(4))
-    
+
+    if minutes == 0 and seconds == 0:
+        return None # No time found
+
     completion_time_seconds = minutes * 60 + seconds
     calculated_score = score_wordsalad(completion_time_seconds, hints_used)
 
@@ -534,111 +536,18 @@ def create_connections_acknowledgement(display_name: str, game_info: Dict[str, A
 def create_framed_acknowledgement(display_name: str, game_info: Dict[str, Any]) -> str:
     return "🤖"
 
-def create_framed_introduction(display_name: str, game_info: Dict[str, Any]) -> str:
-    """Create an informative introduction message for Framed players."""
-    user_id = game_info.get("user_id")
-    stats = database.get_framed_stats(user_id)
-
-    game_number = game_info.get("game_number", "?")
-    attempts = game_info.get("attempts", "?")
-    
-    message = (f"**{display_name}** solved Framed #{game_number} in {attempts} guesses!\n"
-               f"They have played {stats['games_played']} games with an average score of {stats['avg_score']:.2f}.")
-    return message
-
 def create_gisnep_acknowledgement(display_name: str, game_info: Dict[str, Any]) -> str:
     return "🤖"
-
-def create_gisnep_introduction(display_name: str, game_info: Dict[str, Any]) -> str:
-    """Create an informative introduction message for Gisnep players."""
-    user_id = game_info.get("user_id")
-    stats = database.get_gisnep_stats(user_id)
-
-    game_number = game_info.get("game_number", "?")
-    completion_time = game_info.get("completion_time", 0)
-    time_str = f"{completion_time // 60}:{completion_time % 60:02d}"
-
-    message = (f"**{display_name}** finished Gisnep #{game_number} in {time_str}!\n"
-               f"They have played {stats['games_played']} games with an average time of {stats['avg_time']:.2f}s.")
-    return message
 
 def create_bandle_acknowledgement(display_name: str, game_info: Dict[str, Any]) -> str:
     return "🤖"
 
-def create_bandle_introduction(display_name: str, game_info: Dict[str, Any]) -> str:
-    """Create an informative introduction message for Bandle players."""
-    user_id = game_info.get("user_id")
-    stats = database.get_bandle_stats(user_id)
-
-    game_number = game_info.get("game_number", "?")
-    attempts = game_info.get("attempts", "?")
-    
-    message = (f"**{display_name}** finished Bandle #{game_number} in {attempts} attempts!\n"
-               f"They have played {stats['games_played']} games and earned a total of {stats['total_bonus']} bonus points.")
-    return message
-
 def create_minute_cryptic_acknowledgement(display_name: str, game_info: Dict[str, Any]) -> str:
     return "🤖"
     
-def create_minute_cryptic_introduction(display_name: str, game_info: Dict[str, Any]) -> str:
-    """Create an informative introduction message for Minute Cryptic players."""
-    user_id = game_info.get("user_id")
-    stats = database.get_minute_cryptic_stats(user_id)
-
-    game_date = game_info.get("game_date", "?")
-    score_desc = game_info.get("score_description", "?")
-
-    message = (f"**{display_name}** finished the Minute Cryptic for {game_date} with a score of {score_desc}!\n"
-               f"They have played {stats['games_played']} games with an average score of {stats['avg_score']:.2f}.")
-    return message
-
 def create_word_salad_acknowledgement(display_name: str, game_info: Dict[str, Any]) -> str:
     return "🤖"
 
-def create_word_salad_introduction(display_name: str, game_info: Dict[str, Any]) -> str:
-    """Create an informative introduction message for Word Salad players."""
-    user_id = game_info.get("user_id")
-    stats = database.get_word_salad_stats(user_id)
-
-    game_number = game_info.get("game_number", "?")
-    score = game_info.get("score", "?")
-
-    message = (f"**{display_name}** finished Word Salad #{game_number} with a score of {score}!\n"
-               f"They have played {stats['games_played']} games with an average score of {stats['avg_score']:.2f}.")
-    return message
-
 def create_pips_acknowledgement(display_name: str, game_info: Dict[str, Any]) -> str:
     return "🤖"
-
-def create_pips_introduction(display_name: str, game_info: Dict[str, Any]) -> str:
-    """Create introduction message for Pips players."""
-    game_number = game_info.get("game_number", "?")
-    user_id = game_info.get("user_id")
-
-    if user_id is None:
-        return f"🏆 **{display_name}** just completed all Pips difficulties for game #{game_number}!"
-
-    scores = database.get_pips_scores_for_game(user_id, game_number)
-
-    if not scores:
-         return f"🏆 **{display_name}** just completed all Pips difficulties for game #{game_number}!"
-
-    total_score = sum(s['score'] for s in scores)
-    cookie_count = sum(s['cookie'] for s in scores)
-
-    message = f"🏆 **{display_name}** has completed all Pips difficulties for game #{game_number} with a total score of **{total_score}**!\n\n"
-
-    for score in scores:
-        time_min = score['completion_time'] // 60
-        time_sec = score['completion_time'] % 60
-        time_str = f"{time_min}:{time_sec:02d}"
-        message += f"**{score['difficulty'].capitalize()}**: {time_str} ({score['score']} pts)"
-        if score['cookie']:
-            message += " 🍪"
-        message += "\n"
-
-    if cookie_count > 0:
-        message += f"\nWow, {cookie_count} cookie{'s' if cookie_count > 1 else ''}! You're a top performer! 🍪"
-
-    return message
 


### PR DESCRIPTION
This commit refactors the game introduction system to unify all score introductions under `post_generator.generate_post()`.

Previously, introductions were handled inconsistently, with some games using `score_parser.create_introduction` and others relying on logic within `main_bot.py`. This resulted in messy code and incorrect intros for some games.

This change centralizes the introduction logic in `post_generator.py`, ensuring that every game produces its intro/score message via this module.

Changes include:
- Removed all `create_xyz_introduction` functions from `score_parser.py`.
- Removed "create_introduction" keys from `game_config.py`.
- Expanded `post_generator.generate_post()` to include tailored intro formats for all games, including `Minute Cryptic` and `Pips`.
- Refactored `main_bot.py` to remove special-casing for intros and always call `post_generator.generate_post()`.
- Updated `database.py` to track necessary player stats for the new rich introductions.
- Removed the now-unused `introduce_player_in_game_channel` from `role_manager.py`.