### PR TITLE
Fix: Resolve Leaderboard Errors and Connections Score Calculation

### DIFF
--- a/embed_builder.py
+++ b/embed_builder.py
@@ -48,6 +48,122 @@ async def build_wordle_leaderboard_embed(title: str, leaderboard_data: dict, per
     embed.set_footer(text=emit_footer)
     return embed
 
+async def build_sexaginta_leaderboard_embed(title: str, leaderboard_data: dict, period: str, color: discord.Color) -> discord.Embed:
+    """
+    Builds a Discord embed for the Sexaginta-Quattuordle leaderboard.
+    """
+    embed = discord.Embed(
+        title=title,
+        description=f"Period: {period.capitalize()}",
+        color=color
+    )
+
+    # Top Players
+    top_players = leaderboard_data.get("top_players")
+    if top_players:
+        medals = ["🥇", "🥈", "🥉"]
+        player_list = []
+        for i, (player, avg_pct, avg_score, plays) in enumerate(top_players):
+            medal = medals[i] if i < len(medals) else f"**#{i+1}**"
+            avg_pct_safe = _safe_float(avg_pct, 0.0)
+            avg_score_safe = _safe_float(avg_score, 0.0)
+            player_list.append(f"{medal} **{player}** - {avg_pct_safe:.2f}% solved, {avg_score_safe:,.0f} score")
+        embed.add_field(name="🏆 Top Players", value="\\n".join(player_list), inline=False)
+    else:
+        embed.add_field(name="🏆 Top Players", value="No scores recorded for this period.", inline=False)
+
+    # Superlatives
+    superlatives = []
+    strategist = leaderboard_data.get("strategist")
+    if strategist:
+        player, avg_score = strategist
+        avg_score_safe = _safe_float(avg_score, 0.0)
+        superlatives.append(f"🧠 The Strategist to **{player}** for the highest average game score ({avg_score_safe:,.0f}).")
+
+    finisher = leaderboard_data.get("finisher")
+    if finisher:
+        player, avg_pct = finisher
+        avg_pct_safe = _safe_float(avg_pct, 0.0)
+        superlatives.append(f"🏁 The Finisher to **{player}** for the highest average percent solved ({avg_pct_safe:.2f}%).")
+
+    veteran = leaderboard_data.get("veteran")
+    if veteran:
+        player, plays = veteran
+        superlatives.append(f"🎖️ The Veteran to **{player}** for the most games played this period ({plays}).")
+
+    if superlatives:
+        embed.add_field(name="✨ Superlatives", value="\\n".join(superlatives), inline=False)
+
+    emit_footer = f"Posted: {discord.utils.utcnow().strftime('%Y-%m-%d')}"
+    embed.set_footer(text=emit_footer)
+    return embed
+
+async def build_bandle_leaderboard_embed(title: str, leaderboard_data: dict, period: str, color: discord.Color) -> discord.Embed:
+    """
+    Builds a Discord embed for the Bandle leaderboard.
+    """
+    embed = discord.Embed(
+        title=title,
+        description=f"Period: {period.capitalize()}",
+        color=color
+    )
+
+    # Top Players
+    top_players = leaderboard_data.get("top_players")
+    if top_players:
+        medals = ["🥇", "🥈", "🥉"]
+        player_list = []
+        for i, (player, avg_attempts, avg_bonus) in enumerate(top_players):
+            medal = medals[i] if i < len(medals) else f"**#{i+1}**"
+            avg_attempts_safe = _safe_float(avg_attempts, 0.0)
+            player_list.append(f"{medal} **{player}** - Avg. Attempts: {avg_attempts_safe:.2f}")
+        embed.add_field(name="🏆 Top Players", value="\\n".join(player_list), inline=False)
+    else:
+        embed.add_field(name="🏆 Top Players", value="No scores recorded for this period.", inline=False)
+
+    # Superlatives
+    superlatives = []
+    music_historian = leaderboard_data.get("music_historian")
+    if music_historian:
+        player, score = music_historian
+        superlatives.append(f"🧠 The Music Historian to **{player}** ({score} points).")
+
+    ar_scout = leaderboard_data.get("ar_scout")
+    if ar_scout:
+        player, score = ar_scout
+        superlatives.append(f"👀 The A&R Scout to **{player}** ({score} points).")
+
+    producers_ear = leaderboard_data.get("producers_ear")
+    if producers_ear:
+        player, score = producers_ear
+        superlatives.append(f"🎧 The Producer's Ear to **{player}** ({score} points).")
+
+    superfan = leaderboard_data.get("superfan")
+    if superfan:
+        player, score = superfan
+        superlatives.append(f"🤩 The Superfan to **{player}** ({score} points).")
+
+    rock_god = leaderboard_data.get("rock_god")
+    if rock_god:
+        player, streak = rock_god
+        superlatives.append(f"🎸 The Rock God to **{player}** for a streak of {streak}!")
+
+    if superlatives:
+        embed.add_field(name="✨ Weekly Accolades", value="\\n".join(superlatives), inline=False)
+
+    emit_footer = f"Posted: {discord.utils.utcnow().strftime('%Y-%m-%d')}"
+    embed.set_footer(text=emit_footer)
+    return embed
+
+def _safe_float(value, default=0.0):
+    """Safely convert a value to a float, returning a default if conversion fails."""
+    if value is None:
+        return default
+    try:
+        return float(value)
+    except (ValueError, TypeError):
+        return default
+
 async def build_gisnep_leaderboard_embed(title: str, leaderboard_data: dict, period: str, color: discord.Color) -> discord.Embed:
     """
     Builds a Discord embed for the enhanced Gisnep leaderboard.

--- a/game_config.py
+++ b/game_config.py
@@ -85,7 +85,7 @@ GAME_CONFIGS = {
         "save_score_function": database.save_bandle_score,
         "get_leaderboard_function": database.get_bandle_leaderboard,
         "leaderboard_keys": LEADERBOARD_KEY_MAPPINGS["Bandle"],
-        "embed_builder_function": embed_builder.build_leaderboard_embed,
+        "embed_builder_function": embed_builder.build_bandle_leaderboard_embed,
         "get_latest_game_number_function": database.get_latest_game_number_from_db,
         "update_latest_game_number_function": database.update_latest_game_number_in_db,
         "game_number_key": "game_number"
@@ -141,7 +141,7 @@ GAME_CONFIGS = {
         "parse_function": score_parser.parse_sexaginta_score,
         "save_score_function": database.save_sexaginta_score,
         "get_leaderboard_function": database.get_sexaginta_leaderboard,
-        "embed_builder_function": embed_builder.build_leaderboard_embed,
+        "embed_builder_function": embed_builder.build_sexaginta_leaderboard_embed,
         "leaderboard_keys": LEADERBOARD_KEY_MAPPINGS["Sexaginta"],
         "get_latest_game_number_function": database.get_latest_game_number_from_db,
         "update_latest_game_number_function": database.update_latest_game_number_in_db,

--- a/score_parser.py
+++ b/score_parser.py
@@ -162,6 +162,15 @@ def parse_connections_result(message_content: str) -> Optional[Dict[str, Any]]:
     finished_game = len(found_colors) == 4
     perfect_game = finished_game and mistakes == 0
 
+    # Calculate score
+    score_info = calculate_connections_score(
+        guesses=all_guesses,
+        found_colors=found_colors,
+        first_successful=first_successful,
+        mistake_count=mistakes,
+        skill_score=None
+    )
+
     return {
         "game_number": puzzle_number,
         "finished_game": finished_game,
@@ -171,7 +180,8 @@ def parse_connections_result(message_content: str) -> Optional[Dict[str, Any]]:
         "solve_order": solve_order,
         "rainbow_wrong_guess": rainbow_wrong_guess,
         "guesses": all_guesses, # Now contains actual guess content
-        "num_guesses": len(all_guesses)
+        "num_guesses": len(all_guesses),
+        "total_score": score_info['total_score']
     }
 
 def calculate_connections_score(guesses, found_colors, first_successful, mistake_count, skill_score=None):


### PR DESCRIPTION
This commit addresses three separate issues related to the weekly leaderboard generation:

1.  **Bandle and Sexaginta Leaderboard Errors:**
    - **Problem:** The Bandle leaderboard was failing with a `ValueError` (could not convert string to float), and the Sexaginta leaderboard was failing with a `TypeError` (unknown format code 'f').
    - **Root Cause:** Both errors were caused by a data structure mismatch. The `get_*_leaderboard` functions for these games returned a dictionary containing superlatives, but the `game_config.py` was pointing them to a generic embed builder that expected a simple list of data. This caused errors during the sorting and formatting process.
    - **Solution:**
        - Created dedicated embed builder functions (`build_bandle_leaderboard_embed` and `build_sexaginta_leaderboard_embed`) in `embed_builder.py` that are designed to handle the specific dictionary structure, including superlatives, for each game.
        - Introduced a `_safe_float` helper function to prevent crashes from invalid data during float conversion and formatting. - Updated `game_config.py` to use these new, dedicated embed builder functions for Bandle and Sexaginta.

2.  **Connections Leaderboard "None Points" Issue:**
    - **Problem:** The Connections leaderboard was displaying "None points" for all players.
    - **Root Cause:** The `total_score` for Connections games was not being calculated. The `parse_connections_result` function did not call the `calculate_connections_score` function.
    - **Solution:**
        - Modified `parse_connections_result` in `score_parser.py` to call `calculate_connections_score` and include the resulting `total_score` in the dictionary it returns. This makes the score available to the application's main logic to be saved in the database, which will then be correctly reflected on the leaderboard.