### PR TITLE
feat: Add period-over-period comparison stats to leaderboards

### DIFF
--- a/database.py
+++ b/database.py
@@ -942,34 +942,78 @@ def save_word_salad_score(user_id: int, display_name: str, game_number: int,
     conn.commit()
     conn.close()
 
-def get_scores_by_period(period: str, column_name: str = 'created_at') -> tuple[str, tuple]:
-    """Helper function to get the WHERE clause and parameters for a given period."""
+def _get_date_range_for_period(period: str, relative: str = 'current') -> tuple[str, str]:
+    """
+    Calculates the start and end dates for a given period, relative to today.
+    `relative` can be 'current' or 'previous'.
+    """
     today = datetime.date.today()
     if period == 'weekly':
-        # Start of this week (Monday)
-        start_of_week = today - timedelta(days=today.weekday())
-        # Tomorrow (to include today's scores but not future scores)
-        end_date = (today + timedelta(days=1)).isoformat()
-        return (
-            f"WHERE DATE({column_name}, 'localtime') >= DATE(?) "
-            f"AND DATE({column_name}, 'localtime') < DATE(?)",
-            (start_of_week.isoformat(), end_date)
-        )
+        if relative == 'current':
+            start_date = today - timedelta(days=today.weekday())
+            end_date = start_date + timedelta(days=7)
+        else: # previous
+            start_date = today - timedelta(days=today.weekday() + 7)
+            end_date = start_date + timedelta(days=7)
     elif period == 'monthly':
-        # Start of this month
-        start_of_month = today.replace(day=1)
-        # First day of next month
-        if start_of_month.month == 12:
-            next_month = start_of_month.replace(year=start_of_month.year + 1, month=1, day=1)
-        else:
-            next_month = start_of_month.replace(month=start_of_month.month + 1, day=1)
+        if relative == 'current':
+            start_date = today.replace(day=1)
+            end_date = (start_date + timedelta(days=32)).replace(day=1)
+        else: # previous
+            end_of_last_month = today.replace(day=1) - timedelta(days=1)
+            start_date = end_of_last_month.replace(day=1)
+            end_date = (start_date + timedelta(days=32)).replace(day=1)
+    else: # overall
+        return None, None
+
+    return start_date.isoformat(), end_date.isoformat()
+
+def get_scores_by_period(period: str, column_name: str = 'created_at') -> tuple[str, tuple]:
+    """Helper function to get the WHERE clause and parameters for a given period."""
+    start_date, end_date = _get_date_range_for_period(period, 'current')
+
+    if start_date and end_date:
         return (
             f"WHERE DATE({column_name}, 'localtime') >= DATE(?) "
             f"AND DATE({column_name}, 'localtime') < DATE(?)",
-            (start_of_month.isoformat(), next_month.isoformat())
+            (start_date, end_date)
         )
-    else:  # overall
-        return "", ()
+    return "", ()
+
+def get_historical_stats(game_table: str, score_column: str, period: str) -> dict:
+    """
+    Fetches historical statistics (player count, average score) for a game
+    for the previous period.
+    """
+    if period not in ['weekly', 'monthly']:
+        return {}
+
+    start_date, end_date = _get_date_range_for_period(period, 'previous')
+    if not start_date or not end_date:
+        return {}
+
+    conn = sqlite3.connect(DB_NAME)
+    cursor = conn.cursor()
+
+    query = f"""
+        SELECT
+            COUNT(DISTINCT user_id) as player_count,
+            AVG({score_column}) as avg_score
+        FROM {game_table}
+        WHERE DATE(created_at, 'localtime') >= DATE(?) AND DATE(created_at, 'localtime') < DATE(?)
+    """
+
+    try:
+        cursor.execute(query, (start_date, end_date))
+        stats = cursor.fetchone()
+        if stats and stats[0] is not None:
+            return {"player_count": stats[0], "avg_score": stats[1]}
+    except sqlite3.Error as e:
+        print(f"Error fetching historical stats for {game_table}: {e}")
+    finally:
+        conn.close()
+
+    return {}
 
 def get_wordle_leaderboard(period: str = 'weekly'):
     """Fetch enhanced Wordle leaderboard data with superlatives."""
@@ -1022,13 +1066,26 @@ def get_wordle_leaderboard(period: str = 'weekly'):
     """)
     ironman = cursor.fetchone()
 
+    # Get current period stats
+    cursor.execute(f"""
+        SELECT COUNT(DISTINCT user_id), AVG(total_score)
+        FROM wordle_scores
+        {where_clause}
+    """, params)
+    current_stats_result = cursor.fetchone()
+    current_stats = {
+        "player_count": current_stats_result[0] if current_stats_result and current_stats_result[0] is not None else 0,
+        "avg_score": current_stats_result[1] if current_stats_result and current_stats_result[1] is not None else 0.0
+    }
+
     conn.close()
 
     return {
         "top_players": top_players,
         "einstein": einstein,
         "lucky_charm": lucky_charm,
-        "ironman": ironman
+        "ironman": ironman,
+        "current_stats": current_stats
     }
 
 def _parse_uniqueness_to_int(uniqueness_text: str) -> int:
@@ -1112,13 +1169,26 @@ def get_connections_leaderboard(period: str = 'weekly'):
                 best_score = (display_name, uniqueness_text)
         pathfinder = best_score
 
+    # Get current period stats
+    cursor.execute(f"""
+        SELECT COUNT(DISTINCT user_id), AVG(total_score)
+        FROM connections_scores
+        {where_clause}
+    """, params)
+    current_stats_result = cursor.fetchone()
+    current_stats = {
+        "player_count": current_stats_result[0] if current_stats_result and current_stats_result[0] is not None else 0,
+        "avg_score": current_stats_result[1] if current_stats_result and current_stats_result[1] is not None else 0.0
+    }
+
     conn.close()
 
     return {
         "top_players": top_players,
         "perfector": perfector,
         "grandmaster": grandmaster,
-        "pathfinder": pathfinder
+        "pathfinder": pathfinder,
+        "current_stats": current_stats
     }
 
 def get_framed_leaderboard(period: str = 'overall'):
@@ -1141,8 +1211,21 @@ def get_framed_leaderboard(period: str = 'overall'):
         LIMIT 10
     """, params)
     leaderboard = cursor.fetchall()
+
+    # Get current period stats
+    cursor.execute(f"""
+        SELECT COUNT(DISTINCT user_id), AVG(total_score)
+        FROM framed_scores
+        {where_clause}
+    """, params)
+    current_stats_result = cursor.fetchone()
+    current_stats = {
+        "player_count": current_stats_result[0] if current_stats_result and current_stats_result[0] is not None else 0,
+        "avg_score": current_stats_result[1] if current_stats_result and current_stats_result[1] is not None else 0.0
+    }
+
     conn.close()
-    return leaderboard # Returns list of tuples
+    return {"rows": leaderboard, "current_stats": current_stats}
 
 def get_gisnep_leaderboard(period: str = 'weekly'):
     """Fetch enhanced Gisnep leaderboard data with superlatives."""
@@ -1194,12 +1277,25 @@ def get_gisnep_leaderboard(period: str = 'weekly'):
         """, weekly_params)
         scholar_award = cursor.fetchone()
 
+    # Get current period stats
+    cursor.execute(f"""
+        SELECT COUNT(DISTINCT user_id), AVG(completion_time)
+        FROM gisnep_scores
+        {where_clause}
+    """, params)
+    current_stats_result = cursor.fetchone()
+    current_stats = {
+        "player_count": current_stats_result[0] if current_stats_result and current_stats_result[0] is not None else 0,
+        "avg_score": current_stats_result[1] if current_stats_result and current_stats_result[1] is not None else 0.0
+    }
+
     conn.close()
 
     return {
         "top_players": top_players,
         "mercury_award": mercury_award,
-        "scholar_award": scholar_award
+        "scholar_award": scholar_award,
+        "current_stats": current_stats
     }
 
 def get_bandle_leaderboard(period: str = 'weekly'):
@@ -1276,6 +1372,18 @@ def get_bandle_leaderboard(period: str = 'weekly'):
     cursor.execute("SELECT display_name, max_streak FROM player_stats ORDER BY max_streak DESC LIMIT 1")
     rock_god = cursor.fetchone()
 
+    # Get current period stats
+    cursor.execute(f"""
+        SELECT COUNT(DISTINCT user_id), AVG(total_score)
+        FROM bandle_scores
+        {where_clause}
+    """, params)
+    current_stats_result = cursor.fetchone()
+    current_stats = {
+        "player_count": current_stats_result[0] if current_stats_result and current_stats_result[0] is not None else 0,
+        "avg_score": current_stats_result[1] if current_stats_result and current_stats_result[1] is not None else 0.0
+    }
+
     conn.close()
 
     return {
@@ -1284,10 +1392,11 @@ def get_bandle_leaderboard(period: str = 'weekly'):
         "ar_scout": ar_scout,
         "producers_ear": producers_ear,
         "superfan": superfan,
-        "rock_god": rock_god
+        "rock_god": rock_god,
+        "current_stats": current_stats
     }
 
-def get_minute_cryptic_leaderboard(period: str = 'weekly') -> list[tuple[str, int]]:
+def get_minute_cryptic_leaderboard(period: str = 'weekly'):
     """
     Fetches the Minute Cryptic leaderboard data, supporting different periods and stats.
     Currently counts number of puzzles solved (score_value = 0) in the given period.
@@ -1310,8 +1419,21 @@ def get_minute_cryptic_leaderboard(period: str = 'weekly') -> list[tuple[str, in
         LIMIT 10
     """, params)
     leaderboard = cursor.fetchall()
+
+    # Get current period stats
+    cursor.execute(f"""
+        SELECT COUNT(DISTINCT user_id), AVG(score_value)
+        FROM minute_cryptic_scores
+        {where_clause}
+    """, params)
+    current_stats_result = cursor.fetchone()
+    current_stats = {
+        "player_count": current_stats_result[0] if current_stats_result and current_stats_result[0] is not None else 0,
+        "avg_score": current_stats_result[1] if current_stats_result and current_stats_result[1] is not None else 0.0
+    }
+
     conn.close()
-    return leaderboard # Returns list of tuples
+    return {"rows": leaderboard, "current_stats": current_stats}
 
 def get_word_salad_leaderboard(period: str = 'overall'):
     conn = sqlite3.connect(DB_NAME)
@@ -1333,8 +1455,21 @@ def get_word_salad_leaderboard(period: str = 'overall'):
         LIMIT 10
     """, params)
     leaderboard = cursor.fetchall()
+
+    # Get current period stats
+    cursor.execute(f"""
+        SELECT COUNT(DISTINCT user_id), AVG(score)
+        FROM word_salad_scores
+        {where_clause}
+    """, params)
+    current_stats_result = cursor.fetchone()
+    current_stats = {
+        "player_count": current_stats_result[0] if current_stats_result and current_stats_result[0] is not None else 0,
+        "avg_score": current_stats_result[1] if current_stats_result and current_stats_result[1] is not None else 0.0
+    }
+
     conn.close()
-    return leaderboard
+    return {"rows": leaderboard, "current_stats": current_stats}
 
 def get_sexaginta_leaderboard(period="weekly"):
     conn = sqlite3.connect(DB_NAME)
@@ -1388,12 +1523,25 @@ def get_sexaginta_leaderboard(period="weekly"):
     """, params)
     veteran = cursor.fetchone()
 
+    # Get current period stats
+    cursor.execute(f"""
+        SELECT COUNT(DISTINCT user_id), AVG(game_score)
+        FROM sexaginta_scores
+        {where_clause}
+    """, params)
+    current_stats_result = cursor.fetchone()
+    current_stats = {
+        "player_count": current_stats_result[0] if current_stats_result and current_stats_result[0] is not None else 0,
+        "avg_score": current_stats_result[1] if current_stats_result and current_stats_result[1] is not None else 0.0
+    }
+
     conn.close()
     return {
         "top_players": top_players,
         "strategist": strategist,
         "finisher": finisher,
-        "veteran": veteran
+        "veteran": veteran,
+        "current_stats": current_stats
     }
 
 def get_pips_leaderboard(period: str = 'overall'):
@@ -1415,8 +1563,21 @@ def get_pips_leaderboard(period: str = 'overall'):
         LIMIT 10
     """, params)
     leaderboard = cursor.fetchall()
+
+    # Get current period stats
+    cursor.execute(f"""
+        SELECT COUNT(DISTINCT user_id), AVG(score)
+        FROM pips_scores
+        {where_clause}
+    """, params)
+    current_stats_result = cursor.fetchone()
+    current_stats = {
+        "player_count": current_stats_result[0] if current_stats_result and current_stats_result[0] is not None else 0,
+        "avg_score": current_stats_result[1] if current_stats_result and current_stats_result[1] is not None else 0.0
+    }
+
     conn.close()
-    return leaderboard
+    return {"rows": leaderboard, "current_stats": current_stats}
 
 def get_pips_completed_difficulties(user_id: int, game_number: int) -> list[str]:
     """

--- a/embed_builder.py
+++ b/embed_builder.py
@@ -62,6 +62,25 @@ async def build_wordle_leaderboard_embed(title: str, leaderboard_data: dict, per
     if superlatives:
         embed.add_field(name="✨ Superlatives", value="\n".join(superlatives), inline=False)
 
+    # Add historical stats comparison
+    historical_stats = leaderboard_data.get("historical_stats")
+    current_stats = leaderboard_data.get("current_stats")
+
+    if historical_stats and current_stats and period != 'overall':
+        # Player count comparison
+        player_count_change = current_stats["player_count"] - historical_stats["player_count"]
+        player_change_str = f" (+{player_count_change})" if player_count_change > 0 else f" ({player_count_change})" if player_count_change < 0 else ""
+
+        # Average score comparison
+        score_diff = current_stats["avg_score"] - historical_stats["avg_score"]
+        score_change_str = f"up from {historical_stats['avg_score']:.1f}" if score_diff > 0 else f"down from {historical_stats['avg_score']:.1f}" if score_diff < 0 else f"same as last {period}"
+
+        comparison_text = (
+            f"**Players This {period.capitalize()}:** {current_stats['player_count']}{player_change_str}\n"
+            f"**Average Score:** {current_stats['avg_score']:.1f}, {score_change_str}"
+        )
+        embed.add_field(name=f"📊 {period.capitalize()} Report", value=comparison_text, inline=False)
+
     emit_footer = f"Posted: {discord.utils.utcnow().strftime('%Y-%m-%d')}"
     embed.set_footer(text=emit_footer)
     return embed
@@ -264,6 +283,25 @@ async def build_connections_leaderboard_embed(title: str, leaderboard_data: dict
     if superlatives:
         embed.add_field(name="✨ Superlatives", value="\n".join(superlatives), inline=False)
 
+    # Add historical stats comparison
+    historical_stats = leaderboard_data.get("historical_stats")
+    current_stats = leaderboard_data.get("current_stats")
+
+    if historical_stats and current_stats and period != 'overall':
+        # Player count comparison
+        player_count_change = current_stats["player_count"] - historical_stats["player_count"]
+        player_change_str = f" (+{player_count_change})" if player_count_change > 0 else f" ({player_count_change})" if player_count_change < 0 else ""
+
+        # Average score comparison
+        score_diff = current_stats["avg_score"] - historical_stats["avg_score"]
+        score_change_str = f"up from {historical_stats['avg_score']:.1f}" if score_diff > 0 else f"down from {historical_stats['avg_score']:.1f}" if score_diff < 0 else f"same as last {period}"
+
+        comparison_text = (
+            f"**Players This {period.capitalize()}:** {current_stats['player_count']}{player_change_str}\n"
+            f"**Average Score:** {current_stats['avg_score']:.1f}, {score_change_str}"
+        )
+        embed.add_field(name=f"📊 {period.capitalize()} Report", value=comparison_text, inline=False)
+
     emit_footer = f"Posted: {discord.utils.utcnow().strftime('%Y-%m-%d')}"
     embed.set_footer(text=emit_footer)
     return embed
@@ -284,7 +322,7 @@ def _format_sexaginta_fields(row: dict) -> list[str]:
     
     return details
 
-async def build_leaderboard_embed(game_name: str, title: str, rows: list[dict], period: str, color: discord.Color) -> discord.Embed:
+async def build_leaderboard_embed(game_name: str, title: str, leaderboard_data: dict, period: str, color: discord.Color) -> discord.Embed:
     """
     Builds a Discord embed for a game leaderboard, formatted based on game type.
     """
@@ -294,6 +332,7 @@ async def build_leaderboard_embed(game_name: str, title: str, rows: list[dict], 
         color=color
     )
     medals = ["🥇", "🥈", "🥉"]
+    rows = leaderboard_data.get("rows", [])
 
     if not rows:
         return _build_empty_leaderboard_embed(title, period, color)
@@ -438,6 +477,25 @@ async def build_leaderboard_embed(game_name: str, title: str, rows: list[dict], 
             inline=True
         )
 
+    # Add historical stats comparison
+    historical_stats = leaderboard_data.get("historical_stats")
+    current_stats = leaderboard_data.get("current_stats")
+
+    if historical_stats and current_stats and period != 'overall':
+        # Player count comparison
+        player_count_change = current_stats["player_count"] - historical_stats["player_count"]
+        player_change_str = f" (+{player_count_change})" if player_count_change > 0 else f" ({player_count_change})" if player_count_change < 0 else ""
+
+        # Average score comparison
+        score_diff = current_stats["avg_score"] - historical_stats["avg_score"]
+        score_change_str = f"up from {historical_stats['avg_score']:.2f}" if score_diff > 0 else f"down from {historical_stats['avg_score']:.2f}" if score_diff < 0 else f"same as last {period}"
+
+        comparison_text = (
+            f"**Players This {period.capitalize()}:** {current_stats['player_count']}{player_change_str}\n"
+            f"**Average Score:** {current_stats['avg_score']:.2f}, {score_change_str}"
+        )
+        embed.add_field(name=f"📊 {period.capitalize()} Report", value=comparison_text, inline=False)
+
     emit_footer = f"Posted: {discord.utils.utcnow().strftime('%Y-%m-%d')}"
     embed.set_footer(text=emit_footer)
     return embed
@@ -467,11 +525,14 @@ async def build_embed_for_game(game_key, title, leaderboard_data, period, color)
         if not keys:
             raise ValueError(f"Missing leaderboard_keys for generic game {config['name']}")
 
-        rows = [dict(zip(keys, row)) for row in leaderboard_data]
+        rows_as_tuples = leaderboard_data.get("rows", [])
+        rows_as_dicts = [dict(zip(keys, row)) for row in rows_as_tuples]
+        leaderboard_data["rows"] = rows_as_dicts
+
         return await builder_func(
             game_name=config["name"],
             title=title,
-            rows=rows,
+            leaderboard_data=leaderboard_data,
             period=period.capitalize(),
             color=color
         )

--- a/game_config.py
+++ b/game_config.py
@@ -23,6 +23,8 @@ LEADERBOARD_KEY_MAPPINGS = {
 GAME_CONFIGS = {
     "wordle": {
         "name": "Wordle",
+        "table_name": "wordle_scores",
+        "score_column": "total_score",
         "chat_channel_name": "wordle-chat",
         "player_role_name": "wordle-player",
         "parse_function": score_parser.parse_wordle_score,
@@ -37,6 +39,8 @@ GAME_CONFIGS = {
     },
     "connections": {
         "name": "Connections",
+        "table_name": "connections_scores",
+        "score_column": "total_score",
         "chat_channel_name": "connections-chat",
         "player_role_name": "connections-player",
         "parse_function": score_parser.parse_connections_result,
@@ -51,6 +55,8 @@ GAME_CONFIGS = {
     },
     "gisnep": {
         "name": "Gisnep",
+        "table_name": "gisnep_scores",
+        "score_column": "completion_time",
         "chat_channel_name": "gisnep-chat",
         "player_role_name": "gisnep-player",
         "parse_function": score_parser.parse_gisnep_score,
@@ -64,6 +70,8 @@ GAME_CONFIGS = {
     },
     "framed": {
         "name": "Framed",
+        "table_name": "framed_scores",
+        "score_column": "total_score",
         "chat_channel_name": "framed-chat",
         "player_role_name": "framed-player",
         "parse_function": score_parser.parse_framed_score,
@@ -78,6 +86,8 @@ GAME_CONFIGS = {
     },
     "bandle": {
         "name": "Bandle",
+        "table_name": "bandle_scores",
+        "score_column": "total_score",
         "chat_channel_name": "bandle-chat",
         "player_role_name": "bandle-player",
         "parse_function": score_parser.parse_bandle_score,
@@ -92,6 +102,8 @@ GAME_CONFIGS = {
     },
     "minute_cryptic": {
         "name": "Minute Cryptic",
+        "table_name": "minute_cryptic_scores",
+        "score_column": "score_value",
         "chat_channel_name": "minute-cryptic-chat",
         "player_role_name": "minute-cryptic-player",
         "parse_function": score_parser.parse_minute_cryptic_score,
@@ -107,6 +119,8 @@ GAME_CONFIGS = {
     },
     "word_salad": {
         "name": "Word Salad",
+        "table_name": "word_salad_scores",
+        "score_column": "score",
         "chat_channel_name": "word-salad-chat",
         "player_role_name": "word-salad-player",
         "parse_function": score_parser.parse_word_salad_score,
@@ -121,6 +135,8 @@ GAME_CONFIGS = {
     },
     "pips": {
         "name": "Pips",
+        "table_name": "pips_scores",
+        "score_column": "score",
         "chat_channel_name": "pips-chat",
         "player_role_name": "pips-player",
         "parse_function": score_parser.parse_pips_score,
@@ -136,6 +152,8 @@ GAME_CONFIGS = {
     },
     "sexaginta": {
         "name": "Sexaginta-Quattuordle",
+        "table_name": "sexaginta_scores",
+        "score_column": "game_score",
         "aliases": ["64ordle", "sexaginta"],
         "is_game_message": score_parser.is_sexaginta_message,
         "parse_function": score_parser.parse_sexaginta_score,

--- a/main_bot.py
+++ b/main_bot.py
@@ -252,9 +252,19 @@ async def get_leaderboard_embed(game_key: str, period: str) -> Optional[discord.
 
     config = game_config.GAME_CONFIGS[game_key]
     game_name = config["name"]
+    historical_stats = {}
 
     try:
         leaderboard_data = config["get_leaderboard_function"](period=period)
+
+        # Fetch historical stats for comparison
+        if period in ['weekly', 'monthly']:
+            table_name = config.get("table_name")
+            score_column = config.get("score_column")
+            if table_name and score_column:
+                historical_stats = database.get_historical_stats(table_name, score_column, period)
+                leaderboard_data["historical_stats"] = historical_stats
+
     except Exception as e:
         print(f"Error fetching {period} leaderboard for {game_name}: {e}")
         leaderboard_data = {} # Ensure leaderboard_data is a dict


### PR DESCRIPTION
This feature enhances the weekly and monthly leaderboards by adding a new "Report" section that provides period-over-period statistics.

Key changes include:

- A new `get_historical_stats` function in `database.py` to fetch aggregate data (player count, average score) from the previous period.
- Refactored all `get_*_leaderboard` functions in `database.py` to return a consistent dictionary structure that includes current period stats.
- Updated `game_config.py` with `table_name` and `score_column` for each game to support dynamic stat queries.
- Modified `embed_builder.py` to display the comparison between the current and previous period's stats on all leaderboards.
- Adjusted `main_bot.py` to correctly handle the new data structure and pass it to the embed builders.