### PR TITLE
Simplify SexagintaQuattuordle Scoring Logic

### DIFF
--- a/Minigame Scores Examples.fods
+++ b/Minigame Scores Examples.fods
@@ -983,8 +983,8 @@
      <table:table-cell table:style-name="ce7" office:value-type="float" office:value="70" calcext:value-type="float">
       <text:p>70</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce7" office:value-type="float" office:value="2272" calcext:value-type="float">
-      <text:p>2272</text:p>
+     <table:table-cell table:style-name="ce7" office:value-type="float" office:value="67" calcext:value-type="float">
+      <text:p>67</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce7" office:value-type="float" office:value="75" calcext:value-type="float">
       <text:p>75</text:p>

--- a/score_parser.py
+++ b/score_parser.py
@@ -124,8 +124,13 @@ def parse_sexaginta_score(content: str) -> Optional[dict]:
     game_number = int(match.group(1))
     guesses_made = int(match.group(2)) if match.group(2) else None
     words_unsolved = int(match.group(3)) if match.group(3) else None
-    score = int(match.group(4).replace(",", ""))
+    _score_raw = int(match.group(4).replace(",", "")) # kept for variables but unused in new score
     percent_solved = float(match.group(5))
+
+    calc_words_unsolved = words_unsolved if words_unsolved is not None else 0
+    calc_guesses_made = guesses_made if guesses_made is not None else 70
+
+    score = (64 - calc_words_unsolved) + (70 - calc_guesses_made)
 
     # Extract seed from URL
     seed_match = re.search(r"https://64ordle\.au/\?seed=(\d+)", content)


### PR DESCRIPTION
Simplified the score parsing system for 64ordle to use a monotonic scoring formula. Instead of using the raw score value given in the post, the score is now based on attempts and unsolved words (max 70 for 64/70, dropping incrementally for each attempt or unsolved word), rewarding correct attempts and penalizing failures linearly.

Also updated the expected test outputs in `Minigame Scores Examples.fods` to ensure the unit tests pass.

---
*PR created automatically by Jules for task [14763015313577860201](https://jules.google.com/task/14763015313577860201) started by @KjetilAl*